### PR TITLE
Fix SQL prefix cleanup

### DIFF
--- a/nl_sql_generator/main.py
+++ b/nl_sql_generator/main.py
@@ -1,4 +1,4 @@
-import os, random, openai
+import os, random, re, openai
 from nl_sql_generator.prompt_builder import build_prompt
 from nl_sql_generator.sql_validator import SQLValidator
 import argparse, json, yaml
@@ -33,7 +33,8 @@ def cli():
             ],
             temperature=0.2,
         )
-        sql = response.choices[0].message.content.strip().strip("`").replace("SQL", "")
+        raw_sql = response.choices[0].message.content.strip().strip("`")
+        sql = re.sub(r"(?i)^sql\s*", "", raw_sql)
 
         ok, err = validator.check(sql)
         print("📝 NL question:", question)


### PR DESCRIPTION
## Summary
- strip leading `sql` token from responses before validation

## Testing
- `python -m py_compile nl_sql_generator/main.py nl_sql_generator/sql_validator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685a6eac6c832ab2568ac95a41b01a