### PR TITLE
Add OpenAI environment test

### DIFF
--- a/tests/test_openai_env.py
+++ b/tests/test_openai_env.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+from packaging import version
+
+openai = pytest.importorskip("openai")
+
+
+def test_openai_env():
+    if os.getenv("OPENAI_API_KEY") is None:
+        print("Warning: OPENAI_API_KEY is missing")
+
+    assert version.parse(openai.__version__) >= version.parse("1.23.0")
+
+    try:
+        openai.models.list()
+    except (
+        openai.AuthenticationError,
+        openai.PermissionDeniedError,
+        openai.APIConnectionError,
+    ):
+        pytest.skip("OpenAI API unauthorized or unreachable")
+


### PR DESCRIPTION
## Summary
- add pytest check to validate OpenAI client
- improve test to skip when openai is missing or unreachable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68699d5894d4832ab2d1330fd7b64612