### PR TITLE
Add async OpenAI client with streaming and retry

### DIFF
--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+from dataclasses import dataclass
 from typing import List
 
-import openai
+from openai import AsyncOpenAI, OpenAI
+
+
+@dataclass
+class Usage:
+    """Track token usage and cost."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+
+    def add(self, inp: int, out: int, cost: float) -> None:
+        self.input_tokens += inp
+        self.output_tokens += out
+        self.cost_usd += cost
 
 
 def _estimate_cost(input_tokens: int, output_tokens: int, model: str) -> float:
@@ -25,30 +41,72 @@ class ResponsesClient:
         self.tokens_in = 0
         self.tokens_out = 0
         self.cost_spent = 0.0
+        self.usage = Usage()
 
-        openai.api_key = os.getenv("OPENAI_API_KEY")
-        if not openai.api_key:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
             raise RuntimeError("Set OPENAI_API_KEY first")
 
-    def run_jobs(self, messages_list: List[List[dict]]) -> List[str]:
+        self._client = AsyncOpenAI(api_key=api_key)
+        self._sync_client = OpenAI(api_key=api_key)
+        self._max_parallel = int(os.getenv("OPENAI_MAX_PARALLEL", "5"))
+        self._sem = asyncio.Semaphore(self._max_parallel)
+
+    def run_jobs(self, messages_list: List[List[dict]], stream: bool = False) -> List[str]:
         """Execute a batch of message lists and return the responses."""
-        outputs: List[str] = []
-        for messages in messages_list:
-            resp = openai.responses.create(
-                model=self.model,
-                input=messages,
-                stream=False,
-            )
-            in_tok = resp.usage.input_tokens or 0
-            out_tok = resp.usage.output_tokens or 0
-            est_cost = _estimate_cost(in_tok, out_tok, self.model)
-            if self.cost_spent + est_cost > self.budget_usd:
-                raise RuntimeError("Budget exceeded")
-            self.tokens_in += in_tok
-            self.tokens_out += out_tok
-            self.cost_spent += est_cost
-            outputs.append(resp.choices[0].message.content)
-        return outputs
+
+        async def runner() -> List[str]:
+            tasks = [asyncio.create_task(self._worker(m, stream)) for m in messages_list]
+            return await asyncio.gather(*tasks)
+
+        return asyncio.run(runner())
+
+    async def _worker(self, messages: List[dict], stream: bool) -> str:
+        async with self._sem:
+            return await self._request_with_retry(messages, stream)
+
+    async def _request_with_retry(self, messages: List[dict], stream: bool) -> str:
+        delay = 1.0
+        for attempt in range(5):
+            try:
+                if stream:
+                    response = await self._client.chat.completions.create(
+                        model=self.model,
+                        messages=messages,
+                        stream=True,
+                    )
+                    text = ""
+                    async for chunk in response:
+                        text += chunk.choices[0].delta.content or ""
+                    usage = response.usage
+                else:
+                    response = await self._client.chat.completions.create(
+                        model=self.model,
+                        messages=messages,
+                    )
+                    text = response.choices[0].message.content
+                    usage = response.usage
+
+                in_tok = getattr(usage, "input_tokens", getattr(usage, "prompt_tokens", 0)) or 0
+                out_tok = getattr(usage, "output_tokens", getattr(usage, "completion_tokens", 0)) or 0
+                est_cost = _estimate_cost(in_tok, out_tok, self.model)
+
+                if self.cost_spent + est_cost > self.budget_usd:
+                    raise RuntimeError("Budget exceeded")
+
+                self.tokens_in += in_tok
+                self.tokens_out += out_tok
+                self.cost_spent += est_cost
+                self.usage.add(in_tok, out_tok, est_cost)
+                return text
+
+            except Exception:
+                if attempt == 4:
+                    raise
+                await asyncio.sleep(delay)
+                delay *= 2
+
+        raise RuntimeError("Failed to get response after retries")
 
     def remaining_budget(self) -> float:
         """Return remaining budget in USD."""


### PR DESCRIPTION
## Summary
- refactor `ResponsesClient` to use the official OpenAI SDK
- add `Usage` dataclass for cost and token tracking
- implement async batching with streaming and retry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a5f76280832a801189cc0f613f32