### PR TITLE
Add SQL result writer

### DIFF
--- a/nl_sql_generator/requirements.txt
+++ b/nl_sql_generator/requirements.txt
@@ -12,6 +12,7 @@ dill>=0.3.8
 distro>=1.9.0
 filelock>=3.18.0
 frozenlist>=1.7.0
+faker>=18.13.0
 fsspec>=2025.3.0
 greenlet>=3.2.3
 h11>=0.16.0

--- a/nl_sql_generator/writer.py
+++ b/nl_sql_generator/writer.py
@@ -1,0 +1,77 @@
+import os
+import json
+import tempfile
+import datetime
+from typing import Any, Dict, List
+
+from sqlalchemy import create_engine, text
+from faker import Faker
+
+
+class ResultWriter:
+    """Execute SQL and return fake rows for privacy-preserving datasets."""
+
+    def __init__(self, db_url: str | None = None) -> None:
+        db_url = db_url or os.getenv("DATABASE_URL")
+        if not db_url:
+            raise ValueError("DATABASE_URL not set")
+        self.eng = create_engine(db_url, pool_pre_ping=True, connect_args={"sslmode": "require"})
+        self.fake = Faker()
+
+    def fetch(self, sql: str, n_rows: int = 5) -> List[Dict[str, Any]]:
+        """Execute the query and return up to ``n_rows`` fake rows."""
+        with self.eng.connect() as conn:
+            res = conn.execute(text(sql))
+            cols = list(res.keys())
+            rows = res.fetchmany(n_rows)
+
+        data: List[Dict[str, Any]] = []
+        for row in rows:
+            record = {}
+            for col, val in zip(cols, row):
+                record[col] = self._fake_value(col, val)
+            data.append(record)
+        return data
+
+    def write_jsonl(self, rows: List[Dict[str, Any]], path: str) -> None:
+        """Atomically write the ``rows`` to ``path`` in JSONL format."""
+        directory = os.path.dirname(path) or "."
+        with tempfile.NamedTemporaryFile("w", delete=False, dir=directory, suffix=".tmp") as tmp:
+            for r in rows:
+                tmp.write(json.dumps(r))
+                tmp.write("\n")
+            tmp_path = tmp.name
+        os.replace(tmp_path, path)
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _fake_value(self, column: str, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value
+        if isinstance(value, datetime.datetime):
+            return self.fake.date_time_this_decade()
+        if isinstance(value, datetime.date):
+            return self.fake.date_this_decade()
+        if isinstance(value, datetime.time):
+            return self.fake.time()
+        if isinstance(value, str):
+            name = column.lower()
+            if "email" in name:
+                return self.fake.email()
+            if "name" in name:
+                return self.fake.name()
+            if "date" in name:
+                return str(self.fake.date())
+            if "time" in name:
+                return str(self.fake.time())
+            return self.fake.word()
+        # fallback for unsupported types
+        try:
+            return str(value)
+        except Exception:
+            return None

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,56 @@
+import json
+import os
+import sys
+from faker import Faker
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from nl_sql_generator.writer import ResultWriter
+
+
+class _FakeResult:
+    def __init__(self):
+        self._rows = [(1, "Alice", "2024-07-01")]
+
+    def keys(self):
+        return ["id", "name", "created_at"]
+
+    def fetchmany(self, n):
+        return self._rows[:n]
+
+
+class _FakeConn:
+    def execute(self, *_):
+        return _FakeResult()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class _FakeEngine:
+    def connect(self):
+        return _FakeConn()
+
+
+def test_fetch_deterministic(monkeypatch):
+    Faker.seed(99)
+    w = ResultWriter.__new__(ResultWriter)
+    w.eng = _FakeEngine()
+    w.fake = Faker()
+
+    rows1 = w.fetch("SELECT")
+
+    Faker.seed(99)
+    w.fake = Faker()
+    rows2 = w.fetch("SELECT")
+
+    assert rows1 == rows2
+
+
+def test_write_jsonl(tmp_path):
+    w = ResultWriter.__new__(ResultWriter)
+    path = tmp_path / "rows.jsonl"
+    w.write_jsonl([{"a": 1}], path)
+    assert json.loads(path.read_text().strip()) == {"a": 1}


### PR DESCRIPTION
## Summary
- generate synthetic rows with Faker
- allow deterministic patching in tests
- add small unit tests for writer
- install faker in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a6a2aee8832a80641f4987be5edf