### PR TITLE
Add docs and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,48 @@
 # data_generator
-NL‑to‑PostgreSQL Synthetic Data Generator
 
-Turn natural language questions into validated PostgreSQL queries + synthetic result rows.Built for creating LLM training data that pairs NL → SQL → answers.
+**LLM-ready SQL data generator.** Feed it plain-English questions and get vetted
+PostgreSQL queries plus anonymised result rows. The pipeline guards budget via an
+OpenAI cost tracker and modular phases that you can swap out or extend. Use it
+to produce high quality NL ⇢ SQL ⇢ answer triples for training or evaluation.
 
-Features
+## Features
 
-🗄️ Schema‑aware: connects to a read‑only Supabase Postgres instance and introspects tables/columns.
+* 🗄️ Schema introspection from your database
+* 🤖 GPT-driven prompt builder and critic loop
+* ✅ `EXPLAIN`-based SQL validation
+* 🔌 Plug-n-play phases for easy customisation
 
-✨ LLM‑first pipeline: orchestrates GPT‑4o via LangChain, with critic/validator loops.
+## Quick start
 
-✅ SQL safety net: runs EXPLAIN before execution, type‑checks, and catches runtime errors.
-
-🔌 Modular: each pipeline phase (loader, prompt builder, generator, critic, writer) lives in its own file.
-
-Quick Start
-
-# 1. Clone & install
-git clone git@github.com:dhruvd22/data_generator.git
+```bash
+# clone & install
+git clone https://github.com/dhruvd22/data_generator.git
 cd data_generator
-poetry install            # or: pip install -r requirements.txt
+pip install -r nl_sql_generator/requirements.txt
 
-# 2. Set creds
+# set credentials
 export DATABASE_URL="postgresql://user:pass@host:5432/db"
 export OPENAI_API_KEY="sk-..."
 
-# 3. Run the skeleton
-python -m nl_sql_generator.main --config=config.yaml
+# generate via CLI
+python -m nl_sql_generator.main gen questions.txt
 
-Config
+# or from Python
+from nl_sql_generator import AutonomousJob, SchemaLoader
+schema = SchemaLoader.load_schema()
+job = AutonomousJob(schema)
+result = job.run_sync("count the patients")
+print(result.sql, result.rows)
+```
 
-All runtime knobs live in config.yaml. Start with the provided template; tweak counts, budget or model as you iterate.
+## 🔌 How it works
 
-Repo Layout
+1. **main.AutonomousJob** – orchestrates the flow
+2. **SchemaLoader** – pulls table metadata
+3. **PromptBuilder** – crafts the few-shot prompt
+4. **ResponsesClient** – queries OpenAI
+5. **SQLValidator** – checks syntax via `EXPLAIN`
+6. **Critic** – reviews and optionally fixes SQL
+7. **Writer** – executes and fakes result rows
 
-l_sql_generator/
-├── main.py          # CLI entrypoint
-├── schema_loader.py # introspects DB
-├── prompt_builder.py
-├── sql_validator.py
-└── ...
-fewshot/             # prompt example YAMLs
-tests/
-
-Roadmap
-
-Milestone 3 – prompt builder & first end‑to‑end sample
-
-Milestone 4 – batch generation loop
-
-Milestone 5 – dataset packaging + CI tests
-
-Contributing
-
-Fork → branch → PR.
-
-Follow the commit style: feat: …, fix: …, docs: ….
-
-Run pytest before pushing.
+All configuration lives in `config.yaml`.

--- a/nl_sql_generator/critic.py
+++ b/nl_sql_generator/critic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ["Critic"]
+
 import json
 import os
 from datetime import datetime
@@ -19,6 +21,8 @@ class Critic:
         os.makedirs(self.log_dir, exist_ok=True)
 
     def _log(self, data: Dict[str, Any]) -> None:
+        """Append ``data`` to the daily JSONL log file."""
+
         log_path = os.path.join(
             self.log_dir, f"critic-{datetime.utcnow():%Y%m%d}.jsonl"
         )

--- a/nl_sql_generator/logger.py
+++ b/nl_sql_generator/logger.py
@@ -4,6 +4,8 @@ This module provides ``init_logger`` to configure a logger with a pretty
 console output, a rotating log file and an optional JSONL event stream.
 The ``log_call`` decorator can be used to trace function execution.
 
+__all__ = ["Settings", "init_logger", "log_call"]
+
 Example
 -------
 >>> from nl_sql_generator.logger import init_logger, Settings, log_call

--- a/nl_sql_generator/main.py
+++ b/nl_sql_generator/main.py
@@ -1,5 +1,7 @@
 """CLI entrypoints for the NL→SQL generator."""
 
+__all__ = ["cli", "gen"]
+
 import argparse
 import json
 import logging

--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ["ResponsesClient", "Usage"]
+
 import asyncio
 import os
 from dataclasses import dataclass

--- a/nl_sql_generator/prompt_builder.py
+++ b/nl_sql_generator/prompt_builder.py
@@ -1,4 +1,6 @@
-"""Builds the few-shot prompt for the LLM."""
+"""Prompt builder utilities."""
+
+__all__ = ["build_prompt"]
 
 from textwrap import dedent
 import random, json

--- a/nl_sql_generator/schema_loader.py
+++ b/nl_sql_generator/schema_loader.py
@@ -1,15 +1,21 @@
 # nl_sql_generator/schema_loader.py
+"""Database schema introspection helpers."""
+
 from dataclasses import dataclass
 from typing import Dict, List
 from sqlalchemy import create_engine, inspect
 import os, json
 import logging
 
+__all__ = ["SchemaLoader", "ColumnInfo", "TableInfo"]
+
 log = logging.getLogger(__name__)
 
 
 @dataclass
 class ColumnInfo:
+    """Metadata for a database column."""
+
     name: str
     type_: str
     comment: str | None = None
@@ -17,14 +23,18 @@ class ColumnInfo:
 
 @dataclass
 class TableInfo:
+    """Metadata for a database table."""
+
     name: str
     columns: List[ColumnInfo]
     primary_key: str | None = None
 
 
 class SchemaLoader:
+    """Load table definitions from a PostgreSQL database."""
     @staticmethod
     def load_schema(db_url: str | None = None) -> Dict[str, TableInfo]:
+        """Return a mapping of table name to :class:`TableInfo`."""
         db_url = db_url or os.getenv("DATABASE_URL")
         if not db_url:
             raise ValueError("Provide DATABASE_URL env var or param")
@@ -51,6 +61,7 @@ class SchemaLoader:
 
     @staticmethod
     def to_json(schema: Dict[str, TableInfo]) -> dict:
+        """Convert ``schema`` to a JSON-serialisable dict."""
         tables: Dict[str, dict] = {}
         for name, info in schema.items():
             cols = {

--- a/nl_sql_generator/sql_validator.py
+++ b/nl_sql_generator/sql_validator.py
@@ -1,8 +1,12 @@
 """Lightweight validator: run EXPLAIN to catch syntax / unknown table errors."""
+
+__all__ = ["SQLValidator"]
 from sqlalchemy import text, create_engine
 import os
 
 class SQLValidator:
+    """Run ``EXPLAIN`` to verify SQL without executing it."""
+
     def __init__(self, db_url: str | None = None):
         self.db_url = db_url or os.getenv("DATABASE_URL")
         if not self.db_url:

--- a/nl_sql_generator/writer.py
+++ b/nl_sql_generator/writer.py
@@ -1,3 +1,5 @@
+"""Execute SQL and anonymise result rows."""
+
 import os
 import json
 import tempfile
@@ -6,6 +8,8 @@ from typing import Any, Dict, List
 
 from sqlalchemy import create_engine, text
 from faker import Faker
+
+__all__ = ["ResultWriter"]
 
 
 class ResultWriter:
@@ -47,6 +51,7 @@ class ResultWriter:
     # internal helpers
     # ------------------------------------------------------------------
     def _fake_value(self, column: str, value: Any) -> Any:
+        """Return a deterministic fake equivalent for ``value``."""
         if value is None:
             return None
         if isinstance(value, bool):


### PR DESCRIPTION
## Summary
- enrich README with Python and CLI examples
- document public functions & export via `__all__`
- add missing docstrings and comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b14ff8b8832a80212c26660d2859