### PR TITLE
Enable YAML-driven NL→SQL generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ export DATABASE_URL="postgresql://user:pass@host:5432/db"
 export OPENAI_API_KEY="sk-..."
 
 # generate via CLI
-python -m nl_sql_generator.main gen questions.txt
+python -m nl_sql_generator.main gen --config config.yaml
 
 # or from Python
-from nl_sql_generator import AutonomousJob, SchemaLoader
+from nl_sql_generator import AutonomousJob, SchemaLoader, load_tasks
 schema = SchemaLoader.load_schema()
 job = AutonomousJob(schema)
-result = job.run_sync("count the patients")
+tasks = load_tasks("config.yaml")
+result = job.run_task(tasks[0])
 print(result.sql, result.rows)
 ```
 

--- a/nl_sql_generator/__init__.py
+++ b/nl_sql_generator/__init__.py
@@ -1,9 +1,12 @@
 from .autonomous_job import AutonomousJob, JobResult
+from .input_loader import NLTask, load_tasks
 from .logger import Settings, init_logger, log_call
 
 __all__ = [
     "AutonomousJob",
     "JobResult",
+    "NLTask",
+    "load_tasks",
     "Settings",
     "init_logger",
     "log_call",

--- a/nl_sql_generator/critic.py
+++ b/nl_sql_generator/critic.py
@@ -29,8 +29,10 @@ class Critic:
         with open(log_path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(data, ensure_ascii=False) + "\n")
 
-    def review(self, question: str, sql_candidate: str, schema_markdown: str) -> str:
-        """Return vetted SQL, applying model fixes when score < 0.7."""
+    def review(
+        self, question: str, sql_candidate: str, schema_markdown: str
+    ) -> Dict[str, Any]:
+        """Return critic assessment with optional fixes."""
         messages: List[Dict[str, str]] = [
             {
                 "role": "system",
@@ -62,4 +64,4 @@ class Critic:
 
         score = float(result.get("score", 0))
         fixed_sql = str(result.get("fixed_sql", sql_candidate))
-        return fixed_sql if score < 0.7 else sql_candidate
+        return {"fixed_sql": fixed_sql, "score": score}

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -1,0 +1,52 @@
+"""Configuration-driven NL task loader."""
+
+from __future__ import annotations
+
+from typing import TypedDict, List, Dict, Any
+import random
+import yaml
+
+
+class NLTask(TypedDict):
+    """A single natural-language question with context."""
+
+    phase: str
+    question: str
+    metadata: Dict[str, Any]
+
+
+def load_tasks(config_path: str) -> List[NLTask]:
+    """Return a list of :class:`NLTask` parsed from ``config_path``.
+
+    Parameters
+    ----------
+    config_path:
+        Path to a YAML configuration file.
+    """
+    try:
+        with open(config_path, "r", encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:  # pragma: no cover - YAML parser detail
+        raise ValueError("Invalid YAML configuration") from exc
+    if not isinstance(cfg, dict):
+        raise ValueError("Invalid YAML configuration")
+
+    tasks: List[NLTask] = []
+    for phase in cfg.get("phases", []):
+        name = phase.get("name", "unknown")
+        meta = {k: v for k, v in phase.items() if k not in {"name", "questions", "count"}}
+        questions = phase.get("questions")
+        if questions:
+            for q in questions:
+                tasks.append({"phase": name, "question": str(q), "metadata": meta})
+            continue
+
+        count = int(phase.get("count", 0))
+        builtins = meta.get("builtins", [])
+        for i in range(count):
+            builtin = random.choice(builtins) if builtins else "COUNT"
+            table = f"table_{i + 1}"
+            q = f"Write a query using {builtin} on {table}"
+            tasks.append({"phase": name, "question": q, "metadata": meta})
+
+    return tasks

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from nl_sql_generator.input_loader import load_tasks
+
+
+def test_load_tasks_happy(tmp_path):
+    cfg = '''
+phases:
+  - name: demo
+    count: 2
+    builtins: [COUNT]
+'''
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path))
+    assert len(tasks) == 2
+    assert tasks[0]["phase"] == "demo"
+    assert "question" in tasks[0]
+
+
+def test_load_tasks_invalid_yaml(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("::notyaml")
+    with pytest.raises(ValueError):
+        load_tasks(str(bad))
+


### PR DESCRIPTION
## Summary
- add input loader for YAML configs
- refactor main CLI to use YAML tasks
- expose tools API via `AutonomousJob`
- support OpenAI `tools` in responses client
- tweak critic for structured output
- document new usage in README
- add unit tests for input loader

## Testing
- `pip install -q -r nl_sql_generator/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b603dfa8832a8a8576e1b2c961dc