### PR TITLE
Fix openai response variable bug

### DIFF
--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -112,6 +112,7 @@ class ResponsesClient:
                         tool_choice="auto" if tools else None,
                     )
                     message = response.choices[0].message
+                    text = message.content or ""
                     usage = response.usage
 
                 in_tok = getattr(usage, "input_tokens", getattr(usage, "prompt_tokens", 0)) or 0


### PR DESCRIPTION
## Summary
- fix `UnboundLocalError` when requesting completion without streaming
- ensure variable `text` is defined for non-stream responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bf05979c832a9cc5638fc09d86fd