### PR TITLE
Fix table names in tasks and log prompts

### DIFF
--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -15,13 +15,15 @@ class NLTask(TypedDict):
     metadata: Dict[str, Any]
 
 
-def load_tasks(config_path: str) -> List[NLTask]:
+def load_tasks(config_path: str, schema: Dict[str, Any] | None = None) -> List[NLTask]:
     """Return a list of :class:`NLTask` parsed from ``config_path``.
 
     Parameters
     ----------
     config_path:
         Path to a YAML configuration file.
+    schema:
+        Optional mapping of table names used to craft questions.
     """
     try:
         with open(config_path, "r", encoding="utf-8") as fh:
@@ -32,6 +34,7 @@ def load_tasks(config_path: str) -> List[NLTask]:
         raise ValueError("Invalid YAML configuration")
 
     tasks: List[NLTask] = []
+    table_names = list(schema.keys()) if schema else []
     for phase in cfg.get("phases", []):
         name = phase.get("name", "unknown")
         meta = {k: v for k, v in phase.items() if k not in {"name", "questions", "count"}}
@@ -45,7 +48,10 @@ def load_tasks(config_path: str) -> List[NLTask]:
         builtins = meta.get("builtins", [])
         for i in range(count):
             builtin = random.choice(builtins) if builtins else "COUNT"
-            table = f"table_{i + 1}"
+            if table_names:
+                table = random.choice(table_names)
+            else:
+                table = f"table_{i + 1}"
             q = f"Write a query using {builtin} on {table}"
             tasks.append({"phase": name, "question": q, "metadata": meta})
 

--- a/nl_sql_generator/main.py
+++ b/nl_sql_generator/main.py
@@ -44,7 +44,7 @@ def cli() -> None:
         critic=Critic(client=client),
         writer=ResultWriter(),
     )
-    tasks = load_tasks(args.config)
+    tasks = load_tasks(args.config, schema)
     for res in job.run_tasks(tasks[:1]):
         log.info(json.dumps({"question": res.question, "sql": res.sql}))
 
@@ -68,7 +68,7 @@ def gen(config: str = "config.yaml", stream: bool = False) -> None:
         writer=ResultWriter(),
     )
 
-    tasks = load_tasks(config)
+    tasks = load_tasks(config, schema)
     results = job.run_tasks(tasks)
     for r in results:
         typer.echo(json.dumps({"question": r.question, "sql": r.sql, "rows": r.rows}))

--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -10,6 +10,10 @@ from dataclasses import dataclass
 from typing import List
 
 from openai import AsyncOpenAI, OpenAI
+import json
+import logging
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -90,6 +94,7 @@ class ResponsesClient:
         return_message: bool,
     ) -> Any:
         delay = 1.0
+        log.info(json.dumps({"prompt": messages}))
         for attempt in range(5):
             try:
                 if stream:

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -16,10 +16,12 @@ phases:
     path = tmp_path / "cfg.yaml"
     path.write_text(cfg)
 
-    tasks = load_tasks(str(path))
+    schema = {"patients": object()}
+    tasks = load_tasks(str(path), schema)
     assert len(tasks) == 2
     assert tasks[0]["phase"] == "demo"
     assert "question" in tasks[0]
+    assert "patients" in tasks[0]["question"]
 
 
 def test_load_tasks_invalid_yaml(tmp_path):


### PR DESCRIPTION
## Summary
- select actual schema tables when generating tasks
- log every prompt sent to OpenAI
- pass schema into the load_tasks calls
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c0b0dcc0832a8d575be6a267fae4