### PR TITLE
Fix logging of OpenAI prompts

### DIFF
--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -173,7 +173,9 @@ class AutonomousJob:
             msg = self.client.run_jobs([messages], tools=self._tools, return_message=True)[0]
             tool_calls = getattr(msg, "tool_calls", None)
             if tool_calls:
-                messages.append(msg)
+                messages.append(
+                    msg if isinstance(msg, dict) else msg.model_dump()
+                )
                 for call in tool_calls:
                     fn = self._tool_map.get(call.function.name)
                     args = json.loads(call.function.arguments or "{}")

--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -94,7 +94,12 @@ class ResponsesClient:
         return_message: bool,
     ) -> Any:
         delay = 1.0
-        log.info(json.dumps({"prompt": messages}))
+        # Convert any OpenAI message objects to plain dicts for clean logging
+        serializable = [
+            m.model_dump() if hasattr(m, "model_dump") else m for m in messages
+        ]
+        log_str = json.dumps({"prompt": serializable}).replace("\n", "\\n")
+        log.info(log_str)
         for attempt in range(5):
             try:
                 if stream:


### PR DESCRIPTION
## Summary
- sanitize prompts before logging
- avoid storing ChatCompletionMessage objects in prompt history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c2c2b660832a922a8c0426216088