### PR TITLE
Improve quoting in prompts

### DIFF
--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -152,7 +152,8 @@ class AutonomousJob:
             {
                 "role": "system",
                 "content": (
-                    "You are a data-engineer agent. Here is the schema:\n"
+                    "You are a data-engineer agent. Column names in the database are quoted using double quotes."
+                    " Here is the schema:\n"
                     f"{_schema_as_markdown(self.schema)}"
                 ),
             },

--- a/nl_sql_generator/prompt_builder.py
+++ b/nl_sql_generator/prompt_builder.py
@@ -10,7 +10,7 @@ def _schema_as_markdown(schema: Dict[str, Any]) -> str:
     """Render tables & columns as a compact markdown block."""
     lines = []
     for tbl, info in schema.items():
-        cols = ", ".join(c.name for c in info.columns)
+        cols = ", ".join(f'"{c.name}"' for c in info.columns)
         lines.append(f"- **{tbl}**: {cols}")
     return "\n".join(lines)
 
@@ -43,6 +43,7 @@ def build_prompt(
         f"""
         You are a PostgreSQL expert. Given the database schema and a question,
         output **only** the SQL query (no explanation) using valid PostgreSQL syntax.
+        All column names are quoted using double quotes; ensure your SQL does the same.
         {fn_clause}
 
         Schema:


### PR DESCRIPTION
## Summary
- always show schema column names with double quotes
- advise the LLM to quote columns in generated SQL
- mention quoted column names in the system prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c7014ef8832aa662952f4e4d816e