### PR TITLE
Add dataset output config and handle SQL errors

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -2,18 +2,22 @@ phases:
   - name: builtins
     count: 20
     builtins: [COUNT, MAX, AVG]
+    dataset_output_file_dir: generated_datasets/builtins
 
   - name: schema_doc
     count: 40
+    dataset_output_file_dir: generated_datasets/schema_doc
 
 
   - name: single_table
     count: 30
     use_sample_rows: false
+    dataset_output_file_dir: generated_datasets/single_table
 
   - name: joins
     count: 25
     examples_file: fewshot/multi_table_examples.yaml
+    dataset_output_file_dir: generated_datasets/joins
 
 budget_usd: 2.0
 openai_model: gpt-4.1

--- a/nl_sql_generator/writer.py
+++ b/nl_sql_generator/writer.py
@@ -24,10 +24,15 @@ class ResultWriter:
 
     def fetch(self, sql: str, n_rows: int = 5) -> List[Dict[str, Any]]:
         """Execute the query and return up to ``n_rows`` fake rows."""
+        from sqlalchemy.exc import SQLAlchemyError
+
         with self.eng.connect() as conn:
-            res = conn.execute(text(sql))
-            cols = list(res.keys())
-            rows = res.fetchmany(n_rows)
+            try:
+                res = conn.execute(text(sql))
+                cols = list(res.keys())
+                rows = res.fetchmany(n_rows)
+            except SQLAlchemyError as err:  # pragma: no cover - depends on DB
+                raise RuntimeError(f"SQL execution failed: {err}") from err
 
         data: List[Dict[str, Any]] = []
         for row in rows:

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -24,6 +24,20 @@ phases:
     assert "patients" in tasks[0]["question"]
 
 
+def test_metadata_includes_output_dir(tmp_path):
+    cfg = """
+phases:
+  - name: demo
+    count: 1
+    dataset_output_file_dir: out/demo
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"t": object()})
+    assert tasks[0]["metadata"]["dataset_output_file_dir"] == "out/demo"
+
+
 def test_load_tasks_invalid_yaml(tmp_path):
     bad = tmp_path / "bad.yaml"
     bad.write_text("::notyaml")


### PR DESCRIPTION
## Summary
- handle DB errors in `ResultWriter.fetch`
- allow config to specify output directory via `dataset_output_file_dir`
- test that metadata includes this new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c9b1d0a0832a9354768ca9c8b39f