### PR TITLE
Add dataset JSONL output and progress logging

### DIFF
--- a/nl_sql_generator/writer.py
+++ b/nl_sql_generator/writer.py
@@ -52,6 +52,14 @@ class ResultWriter:
             tmp_path = tmp.name
         os.replace(tmp_path, path)
 
+    def append_jsonl(self, row: Dict[str, Any], path: str) -> None:
+        """Append ``row`` as JSON to ``path`` creating directories when needed."""
+        directory = os.path.dirname(path) or "."
+        os.makedirs(directory, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row))
+            fh.write("\n")
+
     # ------------------------------------------------------------------
     # internal helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `append_jsonl` helper to writer
- record progress and write dataset files in `run_tasks`
- log when dataset entries are created

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d1ae0d20832a911d159021a4c945