### PR TITLE
Fix prompt logging format

### DIFF
--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -98,8 +98,12 @@ class ResponsesClient:
         serializable = [
             m.model_dump() if hasattr(m, "model_dump") else m for m in messages
         ]
-        log_str = json.dumps({"prompt": serializable}).replace("\n", "\\n")
-        log.info(log_str)
+
+        # Log the prompt without JSON escape sequences
+        lines = [
+            f"{m.get('role')}: {m.get('content', '')}" for m in serializable
+        ]
+        log.info("Prompt:\n%s", "\n".join(lines))
         for attempt in range(5):
             try:
                 if stream:


### PR DESCRIPTION
## Summary
- improve prompt logging by printing role/content on separate lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae89d4290832aa3db9befeca8a5ec