### PR TITLE
Add single-phase execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ export OPENAI_API_KEY="sk-..."
 
 # generate via CLI (tasks come from config.yaml)
 python -m nl_sql_generator.main gen --config config.yaml
+# run a single phase only
+# python -m nl_sql_generator.main gen --config config.yaml --phase joins
 # no separate questions file is needed
 
 # or from Python
 from nl_sql_generator import AutonomousJob, SchemaLoader, load_tasks
 schema = SchemaLoader.load_schema()
 job = AutonomousJob(schema)
-tasks = load_tasks("config.yaml")
+tasks = load_tasks("config.yaml", phase="joins")
 result = job.run_task(tasks[0])
 print(result.sql, result.rows)
 ```

--- a/nl_sql_generator/main.py
+++ b/nl_sql_generator/main.py
@@ -69,6 +69,7 @@ def cli() -> None:
     """Original quick-start demo using argparse (kept for compatibility)."""
     p = argparse.ArgumentParser()
     p.add_argument("--config", default="config.yaml")
+    p.add_argument("--phase", default=None)
     args = p.parse_args()
 
     if not args.config.lower().endswith((".yaml", ".yml")):
@@ -85,13 +86,17 @@ def cli() -> None:
         critic=Critic(client=client),
         writer=ResultWriter(),
     )
-    tasks = load_tasks(args.config, schema)
+    tasks = load_tasks(args.config, schema, phase=args.phase)
     for res in job.run_tasks(tasks[:1]):
         log.info(json.dumps({"question": res.question, "sql": res.sql}))
 
 
 @app.command()
-def gen(config: str = "config.yaml", stream: bool = False) -> None:
+def gen(
+    config: str = "config.yaml",
+    stream: bool = False,
+    phase: str | None = None,
+) -> None:
     """Generate SQL and result rows for tasks defined in ``config``."""
 
     if not config.lower().endswith((".yaml", ".yml")):
@@ -109,7 +114,7 @@ def gen(config: str = "config.yaml", stream: bool = False) -> None:
         writer=ResultWriter(),
     )
 
-    tasks = load_tasks(config, schema)
+    tasks = load_tasks(config, schema, phase=phase)
     results = job.run_tasks(tasks)
     for r in results:
         typer.echo(json.dumps({"question": r.question, "sql": r.sql, "rows": r.rows}))

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -44,3 +44,19 @@ def test_load_tasks_invalid_yaml(tmp_path):
     with pytest.raises(ValueError):
         load_tasks(str(bad))
 
+
+def test_load_tasks_single_phase(tmp_path):
+    cfg = """
+phases:
+  - name: first
+    count: 1
+  - name: second
+    count: 2
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"t": object()}, phase="second")
+    assert len(tasks) == 2
+    assert all(t["phase"] == "second" for t in tasks)
+


### PR DESCRIPTION
## Summary
- allow InputLoader to filter tasks by phase
- add `--phase` parameter to CLI
- document running a single phase
- test loading a specific phase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae94996e4832a90e850159e1b8c6a