### PR TITLE
Add SAMPLE_DATA phase

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -4,10 +4,12 @@ phases:
       COUNT: 5
       MAX: 5
       AVG: 5
+    use_sample_rows: false
     dataset_output_file_dir: generated_datasets/builtins
 
   - name: schema_doc
     count: 40
+    use_sample_rows: false
     dataset_output_file_dir: generated_datasets/schema_doc
 
 
@@ -19,7 +21,13 @@ phases:
   - name: joins
     count: 25
     examples_file: fewshot/multi_table_examples.yaml
+    use_sample_rows: false
     dataset_output_file_dir: generated_datasets/joins
+
+  - name: sample_data
+    n_rows: 2
+    use_sample_rows: true
+    dataset_output_file_dir: generated_datasets/sample_data
 
 budget_usd: 2.0
 openai_model: gpt-4.1

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -50,6 +50,14 @@ def load_tasks(
             for k, v in phase_def.items()
             if k not in {"name", "questions", "count", "builtins"}
         }
+
+        if name.lower() == "sample_data":
+            n_rows = int(phase_def.get("n_rows", 2))
+            for tbl in table_names:
+                q = f"Show me {n_rows} sample rows from the {tbl} table."
+                meta_with_rows = {**meta, "n_rows": n_rows}
+                tasks.append({"phase": name, "question": q, "metadata": meta_with_rows})
+            continue
         questions = phase_def.get("questions")
         if questions:
             for q in questions:

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -75,3 +75,20 @@ phases:
     assert len(tasks) == 10
     assert {t["metadata"]["builtins"][0] for t in tasks} == {"MAX", "AVG"}
 
+
+def test_sample_data_phase(tmp_path):
+    cfg = """
+phases:
+  - name: sample_data
+    n_rows: 2
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    schema = {"tbl1": object(), "tbl2": object()}
+    tasks = load_tasks(str(path), schema)
+
+    assert len(tasks) == 2
+    assert all("sample rows" in t["question"] for t in tasks)
+    assert all(t["metadata"]["n_rows"] == 2 for t in tasks)
+


### PR DESCRIPTION
## Summary
- add SAMPLE_DATA phase in config
- generate sample rows only in SAMPLE_DATA tasks
- update loader and autonomous job logic
- test new phase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af766009c832aabb64d396bc18ee5