### PR TITLE
Improve documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ print(result.sql, result.rows)
 8. **Writer** – executes and fakes result rows
 
 All configuration lives in `config.yaml`.
+
+## Running tests
+
+This project ships with a small test suite. After installing the runtime
+dependencies, install ``pytest`` and run the tests from the repository root:
+
+```bash
+pip install pytest
+pytest -q
+```

--- a/nl_sql_generator/__init__.py
+++ b/nl_sql_generator/__init__.py
@@ -1,3 +1,10 @@
+"""Convenience re-exports for the public API.
+
+Importing this package exposes commonly used classes and helpers so consumers
+can simply ``from nl_sql_generator import AutonomousJob`` without digging into
+submodules.
+"""
+
 from .autonomous_job import AutonomousJob, JobResult
 from .input_loader import NLTask, load_tasks
 from .logger import Settings, init_logger, log_call

--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -83,6 +83,7 @@ class ResponsesClient:
         tools: List[dict] | None,
         return_message: bool,
     ) -> Any:
+        """Execute a single request with concurrency control."""
         async with self._sem:
             return await self._request_with_retry(messages, stream, tools, return_message)
 
@@ -93,6 +94,7 @@ class ResponsesClient:
         tools: List[dict] | None,
         return_message: bool,
     ) -> Any:
+        """Call the API with exponential backoff retry logic."""
         delay = 1.0
         # Convert any OpenAI message objects to plain dicts for clean logging
         serializable = [


### PR DESCRIPTION
## Summary
- document public API in `__init__`
- add docstrings for internal request helpers
- extend README with section on running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af98982e0832a9df3394a6b414868