### PR TITLE
Sanitize SQL in generated datasets

### DIFF
--- a/tests/test_clean_sql.py
+++ b/tests/test_clean_sql.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from nl_sql_generator.autonomous_job import _clean_sql
+
+
+def test_clean_sql_removes_newlines_and_backslashes():
+    raw = 'SELECT "payers";\n'
+    assert _clean_sql(raw) == 'SELECT "payers";'
+
+
+def test_clean_sql_collapses_whitespace():
+    raw = "SELECT *\nFROM tbl\tWHERE id = 1"
+    assert _clean_sql(raw) == 'SELECT * FROM tbl WHERE id = 1'


### PR DESCRIPTION
## Summary
- clean up SQL output using `_clean_sql`
- sanitize final SQL when generating data
- add tests for `_clean_sql`

## Testing
- `pip install -r nl_sql_generator/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686afa882a20832a85e8d4dbdf37b344