### PR TITLE
Limit dataset output to question and SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # data_generator
 
-**LLM-ready SQL data generator.** That automatically drives through various phases as per config.yaml and generates NL to PostgreSQL datasets plus anonymised result rows. The pipeline guards budget via an
+**LLM-ready SQL data generator.** That automatically drives through various phases as per config.yaml and generates NL to PostgreSQL datasets. Each dataset entry contains only the natural language question and the validated SQL. The pipeline guards budget via an
 OpenAI cost tracker and modular phases that you can swap out or extend. Use it
 to produce high quality NL ⇢ SQL ⇢ answer triples for training or evaluation.
 

--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -170,8 +170,9 @@ class AutonomousJob:
             {
                 "role": "system",
                 "content": (
-                    "You are a data-engineer agent. Column names in the database are quoted using double quotes."
-                    " Here is the schema:\n"
+                    "You are a data-engineer agent. Column names in the database are quoted using double quotes. "
+                    "Return a JSON object with only a 'sql' field containing the valid query. "
+                    "Here is the schema:\n"
                     f"{_schema_as_markdown(self.schema)}"
                 ),
             },
@@ -244,7 +245,7 @@ class AutonomousJob:
             if out_dir:
                 path = os.path.join(out_dir, "dataset.jsonl")
                 self.writer.append_jsonl(
-                    {"question": res.question, "sql": res.sql, "rows": res.rows},
+                    {"question": res.question, "sql": res.sql},
                     path,
                 )
                 log.info("Wrote dataset entry to %s", path)

--- a/tests/test_run_tasks.py
+++ b/tests/test_run_tasks.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from nl_sql_generator.autonomous_job import AutonomousJob, JobResult
+
+
+class DummyClient:
+    def remaining_budget(self):
+        return 1.0
+
+
+class DummyValidator:
+    def check(self, sql):
+        return True, ""
+
+class DummyWriter:
+    def __init__(self):
+        self.seen = []
+    def fetch(self, sql, n_rows=5):
+        return []
+    def append_jsonl(self, row, path):
+        self.seen.append(row)
+
+
+def test_dataset_only_question_sql(tmp_path, monkeypatch):
+    writer = DummyWriter()
+    job = AutonomousJob(
+        {}, writer=writer, client=DummyClient(), validator=DummyValidator(), critic=None
+    )
+    job.run_task = lambda t: JobResult(t['question'], 'SELECT 1', [])
+    t = {'phase': 'demo', 'question': 'foo?', 'metadata': {'dataset_output_file_dir': str(tmp_path)}}
+    job.run_tasks([t])
+    assert writer.seen == [{'question': 'foo?', 'sql': 'SELECT 1'}]


### PR DESCRIPTION
## Summary
- clarify README dataset behaviour
- tell agent to only return SQL in a JSON object
- drop row data from dataset output
- test that `run_tasks` writes only question and SQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686afe66d7fc832a9d02b70193836f6d