### PR TITLE
Fix builtin dataset count and clarify quoting

### DIFF
--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -220,7 +220,7 @@ class AutonomousJob:
             {
                 "role": "system",
                 "content": (
-                    "You are a data-engineer agent. Column names in the database are quoted using double quotes. "
+                    "You are a data-engineer agent. Column names in the database are quoted using double quotes while table names are not. "
                     "Return a JSON object with only a 'sql' field containing the valid query. "
                     "Here is the schema:\n"
                     f"{_schema_as_markdown(self.schema)}"

--- a/nl_sql_generator/main.py
+++ b/nl_sql_generator/main.py
@@ -94,7 +94,7 @@ def cli() -> None:
         writer=ResultWriter(),
     )
     tasks = load_tasks(args.config, schema, phase=args.phase)
-    for res in job.run_tasks(tasks[:1]):
+    for res in job.run_tasks(tasks):
         log.info(json.dumps({"question": res.question, "sql": res.sql}))
 
 

--- a/nl_sql_generator/prompt_builder.py
+++ b/nl_sql_generator/prompt_builder.py
@@ -59,7 +59,7 @@ def build_prompt(
         f"""
         You are a PostgreSQL expert. Given the database schema and a question,
         output **only** the SQL query (no explanation) using valid PostgreSQL syntax.
-        All column names are quoted using double quotes; ensure your SQL does the same.
+        All column names are quoted using double quotes while table names are not; ensure your SQL follows this convention.
         {fn_clause}
 
         Schema:


### PR DESCRIPTION
## Summary
- run all configured tasks in CLI instead of only the first
- clarify quoting rules so only column names get double quotes

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0450ad6c832a89ce8ac5edd8a9f7