### PR TITLE
Remove quoting instructions

### DIFF
--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -220,7 +220,7 @@ class AutonomousJob:
             {
                 "role": "system",
                 "content": (
-                    "You are a data-engineer agent. Column names in the database are quoted using double quotes while table names are not. "
+                    "You are a data-engineer agent. "
                     "Return a JSON object with only a 'sql' field containing the valid query. "
                     "Here is the schema:\n"
                     f"{_schema_as_markdown(self.schema)}"

--- a/nl_sql_generator/prompt_builder.py
+++ b/nl_sql_generator/prompt_builder.py
@@ -59,7 +59,6 @@ def build_prompt(
         f"""
         You are a PostgreSQL expert. Given the database schema and a question,
         output **only** the SQL query (no explanation) using valid PostgreSQL syntax.
-        All column names are quoted using double quotes while table names are not; ensure your SQL follows this convention.
         {fn_clause}
 
         Schema:


### PR DESCRIPTION
## Summary
- remove mention about quoting column and table names from SQL prompt
- update default autonomous job message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf0edc2b4832a8c3d7419feff2816