### PR TITLE
Update builtin phase and add prompt templates

### DIFF
--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -167,12 +167,15 @@ class AutonomousJob:
     @log_call
     def _tool_generate_sql(self, nl_question: str) -> str:
         """LLM tool: generate SQL for ``nl_question``."""
-        prompt = build_prompt(nl_question, self.schema, self.phase_cfg)
+        prompt_obj = build_prompt(nl_question, self.schema, self.phase_cfg)
         log.info("Generating SQL for question: %s", nl_question)
-        messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt},
-        ]
+        if isinstance(prompt_obj, list):
+            messages = prompt_obj
+        else:
+            messages = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt_obj},
+            ]
         sql = self.client.run_jobs([messages])[0]
         sql = sql.strip().strip("`")
         sql = re.sub(r"(?i)^sql\s*", "", sql)

--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -1,14 +1,13 @@
 phases:
   - name: builtins
-    builtins:
-      COUNT: 5
-      MAX: 5
-      AVG: 5
+    count: 5
+    builtins: [COUNT, MAX, AVG]
     use_sample_rows: false
     dataset_output_file_dir: generated_datasets/builtins
 
   - name: schema_doc
     count: 40
+    prompt_template: 00_schema-doc_QA_prompt.txt
     use_sample_rows: false
     dataset_output_file_dir: generated_datasets/schema_doc
 

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -95,22 +95,14 @@ def load_tasks(
             continue
 
         if isinstance(builtins_spec, list):
-            if count:
-                for i in range(count):
-                    builtin = random.choice(builtins_spec)
+            per_fn = count or 5
+            for fn in builtins_spec:
+                for i in range(per_fn):
                     table = random.choice(table_names) if table_names else f"table_{i + 1}"
-                    q = f"Write a query using {builtin} on {table}"
-                    meta_with_fn = {**meta, "builtins": [builtin]}
+                    q = f"Write a query using {fn} on {table}"
+                    meta_with_fn = {**meta, "builtins": [fn]}
                     tasks.append({"phase": name, "question": q, "metadata": meta_with_fn})
-                continue
-            else:
-                for fn in builtins_spec:
-                    for i in range(5):
-                        table = random.choice(table_names) if table_names else f"table_{i + 1}"
-                        q = f"Write a query using {fn} on {table}"
-                        meta_with_fn = {**meta, "builtins": [fn]}
-                        tasks.append({"phase": name, "question": q, "metadata": meta_with_fn})
-                continue
+            continue
 
         builtins = meta.get("builtins", [])
         for i in range(count):

--- a/nl_sql_generator/prompt_template/00_schema-doc_QA_prompt.txt
+++ b/nl_sql_generator/prompt_template/00_schema-doc_QA_prompt.txt
@@ -1,0 +1,17 @@
+### role: system
+You are a senior data-warehouse architect.
+Given a JSON schema, produce human-readable docs plus NL questions that *explain* the schema.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}
+
+TASKS:
+1. Concisely describe each table and its business meaning.
+2. For every foreign-key relation, write two natural-language questions whose answer would require that join.
+3. Return a JSON list with keys:
+   - table_name
+   - table_doc
+   - sample_questions (array of strings)
+
+Output JSON only.

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -76,6 +76,22 @@ phases:
     assert {t["metadata"]["builtins"][0] for t in tasks} == {"MAX", "AVG"}
 
 
+def test_builtins_list_with_count(tmp_path):
+    cfg = """
+phases:
+  - name: demo
+    count: 3
+    builtins: [SUM, MIN]
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"t": object()})
+    # two functions * count 3 each
+    assert len(tasks) == 6
+    assert all(t["metadata"]["builtins"][0] in {"SUM", "MIN"} for t in tasks)
+
+
 def test_sample_data_phase(tmp_path):
     cfg = """
 phases:

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from nl_sql_generator.prompt_builder import load_template_messages
+
+
+def test_load_template_messages(tmp_path):
+    tmpl_name = "_tmp_prompt.txt"
+    tmpl_dir = os.path.join(os.path.dirname(__file__), "..", "nl_sql_generator", "prompt_template")
+    os.makedirs(tmpl_dir, exist_ok=True)
+    path = os.path.join(tmpl_dir, tmpl_name)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("### role: system\nfoo\n### role: user\n{{nl_question}}")
+    try:
+        msgs = load_template_messages(tmpl_name, {"t": 1}, "Q?")
+        assert msgs[0]["role"] == "system"
+        assert msgs[1]["role"] == "user"
+        assert "Q?" in msgs[1]["content"]
+    finally:
+        os.remove(path)


### PR DESCRIPTION
## Summary
- support per-phase prompt templates
- implement builtin count per function
- add Schema-doc QA template and configuration
- test new behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf3ce0574832a9527f35a2a4c1589