### PR TITLE
Fix schema_doc prompt template handling

### DIFF
--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -82,6 +82,13 @@ def load_tasks(
                 tasks.append({"phase": name, "question": str(q), "metadata": meta})
             continue
 
+        if phase_def.get("prompt_template") and not phase_def.get("builtins"):
+            count = int(phase_def.get("count", 1))
+            q = str(phase_def.get("question", ""))
+            for _ in range(count):
+                tasks.append({"phase": name, "question": q, "metadata": meta})
+            continue
+
         builtins_spec = phase_def.get("builtins")
         count = int(phase_def.get("count", 0))
 

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -107,3 +107,19 @@ phases:
     assert len(tasks) == 2
     assert all("sample rows" in t["question"] for t in tasks)
     assert all(t["metadata"]["n_rows"] == 2 for t in tasks)
+
+
+def test_prompt_template_phase(tmp_path):
+    cfg = """
+phases:
+  - name: schema_doc
+    count: 2
+    prompt_template: doc.txt
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"tbl": object()})
+    assert len(tasks) == 2
+    assert all(t["question"] == "" for t in tasks)
+    assert all(t["metadata"]["prompt_template"] == "doc.txt" for t in tasks)


### PR DESCRIPTION
## Summary
- ensure phases with `prompt_template` but no builtins/questions generate tasks using that template
- cover this behaviour with a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfab3927c832aa65fc3d2490a58eb