### PR TITLE
Add schema_docs phase for schema QA pairs

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -11,6 +11,12 @@ phases:
     use_sample_rows: false
     dataset_output_file_dir: generated_datasets/schema_doc
 
+  - name: schema_docs
+    count: 5
+    prompt_template: schema_doc_template.txt
+    use_sample_rows: false
+    dataset_output_file_dir: generated_datasets/schema_docs
+
 
   - name: single_table
     count: 30

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -76,6 +76,17 @@ def load_tasks(
                 meta_with_rows = {**meta, "n_rows": n_rows}
                 tasks.append({"phase": name, "question": q, "metadata": meta_with_rows})
             continue
+        if name.lower() == "schema_docs":
+            count = int(phase_def.get("count", 1))
+            q = str(
+                phase_def.get(
+                    "question",
+                    f"Generate {count} unique question-answer pairs about the schema.",
+                )
+            )
+            meta_with_count = {**meta, "count": count}
+            tasks.append({"phase": name, "question": q, "metadata": meta_with_count})
+            continue
         questions = phase_def.get("questions")
         if questions:
             for q in questions:

--- a/nl_sql_generator/prompt_template/schema_doc_template.txt
+++ b/nl_sql_generator/prompt_template/schema_doc_template.txt
@@ -1,0 +1,8 @@
+### role: system
+You are a senior data-warehouse architect. Given the database schema in JSON format, generate concise question and answer pairs explaining the schema. Each answer should be a factual statement about the schema. Return one JSON object per line with keys "question" and "answer" only.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}
+
+{{nl_question}}

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -123,3 +123,19 @@ phases:
     assert len(tasks) == 2
     assert all(t["question"] == "" for t in tasks)
     assert all(t["metadata"]["prompt_template"] == "doc.txt" for t in tasks)
+
+
+def test_schema_docs_phase(tmp_path):
+    cfg = """
+phases:
+  - name: schema_docs
+    count: 3
+    prompt_template: schema_doc_template.txt
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"tbl": object()})
+    assert len(tasks) == 1
+    assert tasks[0]["phase"] == "schema_docs"
+    assert tasks[0]["metadata"]["count"] == 3

--- a/tests/test_run_tasks.py
+++ b/tests/test_run_tasks.py
@@ -58,3 +58,20 @@ def test_schema_doc_dataset(tmp_path):
     }
     job.run_tasks([t])
     assert writer.seen == [{"question": "Q1", "doc": "doc"}]
+
+
+def test_schema_docs_dataset(tmp_path):
+    writer = DummyWriter()
+    job = AutonomousJob(
+        {}, writer=writer, client=DummyClient(), validator=DummyValidator(), critic=None
+    )
+
+    job._run_schema_docs = lambda t: JobResult("", "", [{"question": "Q?", "answer": "A"}])
+
+    t = {
+        "phase": "schema_docs",
+        "question": "",
+        "metadata": {"dataset_output_file_dir": str(tmp_path)},
+    }
+    job.run_tasks([t])
+    assert writer.seen == [{"question": "Q?", "answer": "A"}]


### PR DESCRIPTION
## Summary
- support new `schema_docs` phase in config & task loader
- add template for generating schema documentation question-answer pairs
- implement `_run_schema_docs` workflow in `AutonomousJob`
- write schema QA datasets via writer
- test coverage for new loader and dataset logic

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0906ac68832a9f5be7a5811cc037