### PR TITLE
feat(parallelism): add async helper-agent pool for large generation counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,11 @@ following before committing changes:
 black --line-length 100 .
 ruff check --fix .
 ```
+
+## Scaling & Parallelism
+
+You can control how many helper agents run concurrently via the `parallelism` setting.
+Set a global default under `defaults` in `config.yaml` or override per phase. The
+`DG_PARALLELISM` environment variable takes precedence. The dispatcher fans out
+async helper agents which merge their unique question–answer pairs before
+writing the dataset.

--- a/nl_sql_generator/agent_pool.py
+++ b/nl_sql_generator/agent_pool.py
@@ -1,0 +1,38 @@
+import asyncio
+import math
+import itertools
+from typing import Any, Dict, List
+
+from .worker_agent import WorkerAgent
+
+
+class AgentPool:
+    def __init__(
+        self, schema: Dict[str, Any], phase_cfg: Dict[str, Any], validator_cls, writer
+    ) -> None:
+        self.schema = schema
+        self.cfg = phase_cfg
+        self.validator_cls = validator_cls
+        self.writer = writer
+        self.seen: set[tuple[str, str]] = set()
+        self.lock = asyncio.Lock()
+
+    async def _run_worker(self, batch_size: int, worker_id: int) -> int:
+        agent = WorkerAgent(self.schema, self.cfg, self.validator_cls, worker_id)
+        pairs = await agent.generate(batch_size)
+        async with self.lock:
+            before = len(self.seen)
+            for p in pairs:
+                self.seen.add((p["question"], p["answer"]))
+            delta = len(self.seen) - before
+        return delta
+
+    async def generate(self) -> List[Dict[str, str]]:
+        goal = int(self.cfg.get("count", 1))
+        k = math.ceil(goal / int(self.cfg.get("parallelism", 1)))
+        attempts = 0
+        while len(self.seen) < goal and attempts < self.cfg.get("max_attempts", 6):
+            jobs = [self._run_worker(k, i) for i in range(int(self.cfg.get("parallelism", 1)))]
+            await asyncio.gather(*jobs)
+            attempts += 1
+        return [{"question": q, "answer": a} for q, a in itertools.islice(self.seen, goal)]

--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -1,3 +1,5 @@
+defaults:
+  parallelism: 4
 phases:
   - name: builtins
     count: 5
@@ -7,6 +9,8 @@ phases:
 
   - name: schema_docs
     count: 5
+    parallelism: 10
+    openai_model: gpt-4o-mini
     prompt_template: schema_doc_template.txt
     use_sample_rows: false
     dataset_output_file_dir: generated_datasets/schema_docs

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -56,6 +56,7 @@ def load_tasks(
         raise ValueError("Invalid YAML configuration") from exc
     if not isinstance(cfg, dict):
         raise ValueError("Invalid YAML configuration")
+    defaults = cfg.get("defaults", {})
 
     tasks: List[NLTask] = []
     table_names = list(schema.keys()) if schema else []
@@ -64,9 +65,12 @@ def load_tasks(
         if phase and name != phase:
             continue
         meta = {
-            k: v
-            for k, v in phase_def.items()
-            if k not in {"name", "questions", "count", "builtins"}
+            **defaults,
+            **{
+                k: v
+                for k, v in phase_def.items()
+                if k not in {"name", "questions", "count", "builtins"}
+            },
         }
 
         if name.lower() == "sample_data":

--- a/nl_sql_generator/prompt_builder.py
+++ b/nl_sql_generator/prompt_builder.py
@@ -10,7 +10,7 @@ Example:
     You are a PostgreSQL expert.
 """
 
-__all__ = ["build_prompt", "load_template_messages"]
+__all__ = ["build_prompt", "load_template_messages", "build_schema_doc_prompt"]
 
 from textwrap import dedent
 import random
@@ -69,6 +69,14 @@ def load_template_messages(
     if role is not None:
         messages.append({"role": role, "content": "\n".join(buf).strip()})
     return messages
+
+
+def build_schema_doc_prompt(schema: Dict[str, Any], k: int = 1) -> List[Dict[str, str]]:
+    """Return chat messages to generate ``k`` schema QA pairs."""
+
+    subset = SchemaLoader.to_json(schema, max_tables=8)
+    question = f"Generate {k} unique question-answer pairs about the schema."
+    return load_template_messages("schema_doc_template.txt", subset, question)
 
 
 def build_prompt(

--- a/nl_sql_generator/schema_loader.py
+++ b/nl_sql_generator/schema_loader.py
@@ -94,10 +94,22 @@ class SchemaLoader:
         return schema
 
     @staticmethod
-    def to_json(schema: Dict[str, TableInfo]) -> dict:
-        """Convert ``schema`` to a JSON-serialisable dict."""
+    def to_json(schema: Dict[str, TableInfo], max_tables: int | None = None) -> dict:
+        """Convert ``schema`` to a JSON-serialisable dict.
+
+        Args:
+            schema: Mapping of table names to :class:`TableInfo`.
+            max_tables: Optional limit on the number of tables to include.
+        """
+
+        items = list(schema.items())
+        if max_tables is not None:
+            import random
+
+            items = random.sample(items, k=min(max_tables, len(items)))
+
         tables: Dict[str, dict] = {}
-        for name, info in schema.items():
+        for name, info in items:
             cols = {c.name: {"type": c.type_, "comment": c.comment} for c in info.columns}
             tables[name] = {
                 "columns": cols,

--- a/nl_sql_generator/validator.py
+++ b/nl_sql_generator/validator.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+
+class NoOpValidator:
+    """Validator that always succeeds."""
+
+    def check(self, sql: str) -> Tuple[bool, str | None]:
+        return True, None

--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -1,0 +1,21 @@
+import json
+from typing import Any, Dict, List
+
+from .prompt_builder import build_schema_doc_prompt
+from .openai_responses import acomplete
+
+
+class WorkerAgent:
+    def __init__(
+        self, schema: Dict[str, Any], cfg: Dict[str, Any], validator_cls, wid: int
+    ) -> None:
+        self.schema = schema
+        self.cfg = cfg
+        self.validator = validator_cls()
+        self.wid = wid
+
+    async def generate(self, k: int) -> List[Dict[str, str]]:
+        prompt = build_schema_doc_prompt(self.schema, k=k)
+        completion = await acomplete(prompt, model=self.cfg.get("openai_model"))
+        pairs = [json.loads(line) for line in completion.strip().splitlines() if line.strip()]
+        return pairs

--- a/tests/test_parallel_schema_docs.py
+++ b/tests/test_parallel_schema_docs.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nl_sql_generator.agent_pool import AgentPool
+import nl_sql_generator.agent_pool as agent_pool
+
+
+class DummyWorker:
+    def __init__(self, schema, cfg, validator_cls, wid):
+        self.wid = wid
+
+    async def generate(self, k):
+        return [{"question": f"Q{self.wid}-{i}", "answer": f"A{i}"} for i in range(k)]
+
+
+def test_pool_dedup(monkeypatch):
+    monkeypatch.setattr(agent_pool, "WorkerAgent", DummyWorker)
+    cfg = {"count": 5, "parallelism": 2}
+    pool = AgentPool({}, cfg, lambda: None, None)
+    pairs = asyncio.run(pool.generate())
+    assert len(pairs) == 5
+    assert len({(p["question"], p["answer"]) for p in pairs}) == 5

--- a/tests/test_run_tasks.py
+++ b/tests/test_run_tasks.py
@@ -31,7 +31,11 @@ def test_dataset_only_question_sql(tmp_path, monkeypatch):
     job = AutonomousJob(
         {}, writer=writer, client=DummyClient(), validator=DummyValidator(), critic=None
     )
-    job.run_task = lambda t: JobResult(t["question"], "SELECT 1", [])
+
+    async def _rt(t):
+        return JobResult(t["question"], "SELECT 1", [])
+
+    job.run_task = _rt
     t = {
         "phase": "demo",
         "question": "foo?",
@@ -41,14 +45,16 @@ def test_dataset_only_question_sql(tmp_path, monkeypatch):
     assert writer.seen == [{"question": "foo?", "sql": "SELECT 1"}]
 
 
-
 def test_schema_docs_dataset(tmp_path):
     writer = DummyWriter()
     job = AutonomousJob(
         {}, writer=writer, client=DummyClient(), validator=DummyValidator(), critic=None
     )
 
-    job._run_schema_docs = lambda t: JobResult("", "", [{"question": "Q?", "answer": "A"}])
+    async def _sd(t):
+        return JobResult("", "", [{"question": "Q?", "answer": "A"}])
+
+    job._run_schema_docs_async = _sd
 
     t = {
         "phase": "schema_docs",


### PR DESCRIPTION
## Summary
- add AgentPool and WorkerAgent async modules
- track cost accounting with locks and expose acomplete
- async run_task and dispatcher for schema docs
- support default parallelism in config and input loader
- document scaling options in README
- add unit tests for parallel schema doc generation

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c1ab6bcd0832ab6e93891461a27e9