### PR TITLE
Fix schema_docs budget handling

### DIFF
--- a/nl_sql_generator/agent_pool.py
+++ b/nl_sql_generator/agent_pool.py
@@ -4,21 +4,34 @@ import itertools
 from typing import Any, Dict, List
 
 from .worker_agent import WorkerAgent
+from .openai_responses import ResponsesClient
 
 
 class AgentPool:
     def __init__(
-        self, schema: Dict[str, Any], phase_cfg: Dict[str, Any], validator_cls, writer
+        self,
+        schema: Dict[str, Any],
+        phase_cfg: Dict[str, Any],
+        validator_cls,
+        writer,
+        client: ResponsesClient,
     ) -> None:
         self.schema = schema
         self.cfg = phase_cfg
         self.validator_cls = validator_cls
         self.writer = writer
+        self.client = client
         self.seen: set[tuple[str, str]] = set()
         self.lock = asyncio.Lock()
 
     async def _run_worker(self, batch_size: int, worker_id: int) -> int:
-        agent = WorkerAgent(self.schema, self.cfg, self.validator_cls, worker_id)
+        agent = WorkerAgent(
+            self.schema,
+            self.cfg,
+            self.validator_cls,
+            worker_id,
+            self.client,
+        )
         pairs = await agent.generate(batch_size)
         async with self.lock:
             before = len(self.seen)

--- a/nl_sql_generator/autonomous_job.py
+++ b/nl_sql_generator/autonomous_job.py
@@ -168,7 +168,13 @@ class AutonomousJob:
         from .agent_pool import AgentPool
         from .validator import NoOpValidator
 
-        pool = AgentPool(self.schema, task.get("metadata", {}), NoOpValidator, self.writer)
+        pool = AgentPool(
+            self.schema,
+            task.get("metadata", {}),
+            NoOpValidator,
+            self.writer,
+            self.client,
+        )
         pairs = await pool.generate()
         return JobResult(task.get("question", ""), "", pairs)
 

--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -211,7 +211,18 @@ class ResponsesClient:
                 est_cost = _estimate_cost(in_tok, out_tok, self.model)
 
                 if self.cost_spent + est_cost > self.budget_usd:
-                    raise RuntimeError("Budget exceeded")
+                    log.error(
+                        "Budget exceeded: cost=$%.4f spent=$%.4f budget=$%.4f",
+                        est_cost,
+                        self.cost_spent,
+                        self.budget_usd,
+                    )
+                    raise RuntimeError(
+                        (
+                            "Budget exceeded: spent=$%.4f + est=$%.4f > budget=$%.4f"
+                        )
+                        % (self.cost_spent, est_cost, self.budget_usd)
+                    )
 
                 async with self._lock:
                     self.tokens_in += in_tok

--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -2,20 +2,28 @@ import json
 from typing import Any, Dict, List
 
 from .prompt_builder import build_schema_doc_prompt
-from .openai_responses import acomplete
+from .openai_responses import ResponsesClient
 
 
 class WorkerAgent:
     def __init__(
-        self, schema: Dict[str, Any], cfg: Dict[str, Any], validator_cls, wid: int
+        self,
+        schema: Dict[str, Any],
+        cfg: Dict[str, Any],
+        validator_cls,
+        wid: int,
+        client: ResponsesClient,
     ) -> None:
         self.schema = schema
         self.cfg = cfg
         self.validator = validator_cls()
         self.wid = wid
+        self.client = client
 
     async def generate(self, k: int) -> List[Dict[str, str]]:
         prompt = build_schema_doc_prompt(self.schema, k=k)
-        completion = await acomplete(prompt, model=self.cfg.get("openai_model"))
+        completion = await self.client.acomplete(
+            prompt, model=self.cfg.get("openai_model")
+        )
         pairs = [json.loads(line) for line in completion.strip().splitlines() if line.strip()]
         return pairs

--- a/tests/test_parallel_schema_docs.py
+++ b/tests/test_parallel_schema_docs.py
@@ -9,7 +9,7 @@ import nl_sql_generator.agent_pool as agent_pool
 
 
 class DummyWorker:
-    def __init__(self, schema, cfg, validator_cls, wid):
+    def __init__(self, schema, cfg, validator_cls, wid, client):
         self.wid = wid
 
     async def generate(self, k):
@@ -19,7 +19,7 @@ class DummyWorker:
 def test_pool_dedup(monkeypatch):
     monkeypatch.setattr(agent_pool, "WorkerAgent", DummyWorker)
     cfg = {"count": 5, "parallelism": 2}
-    pool = AgentPool({}, cfg, lambda: None, None)
+    pool = AgentPool({}, cfg, lambda: None, None, None)
     pairs = asyncio.run(pool.generate())
     assert len(pairs) == 5
     assert len({(p["question"], p["answer"]) for p in pairs}) == 5


### PR DESCRIPTION
## Summary
- ensure worker agents reuse the job's OpenAI client
- log remaining budget details when budget exceeds
- adjust tests for the new AgentPool API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2bf26334832aa9041327b07d2aad