### PR TITLE
Fix worker_agent JSON parse error

### DIFF
--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -1,6 +1,32 @@
 import json
 from typing import Any, Dict, List
 
+
+def _parse_pairs(text: str) -> List[Dict[str, str]]:
+    """Return JSON objects from ``text`` one per valid line.
+
+    The OpenAI responses occasionally include markdown fences or extra prose.
+    This helper skips such lines and ignores JSON decode errors so that callers
+    only receive well formed ``{"question": ..., "answer": ...}`` mappings.
+    """
+
+    pairs: List[Dict[str, str]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("```"):
+            continue
+        # Drop common list prefixes like "-" or "1." and code fence ticks
+        line = line.lstrip("-*0123456789. ").strip('`')
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            pairs.append(obj)
+    return pairs
+
 from .prompt_builder import build_schema_doc_prompt
 from .openai_responses import ResponsesClient
 
@@ -23,5 +49,5 @@ class WorkerAgent:
     async def generate(self, k: int) -> List[Dict[str, str]]:
         prompt = build_schema_doc_prompt(self.schema, k=k)
         completion = await self.client.acomplete(prompt, model=self.cfg.get("openai_model"))
-        pairs = [json.loads(line) for line in completion.strip().splitlines() if line.strip()]
+        pairs = _parse_pairs(completion)
         return pairs

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -1,0 +1,26 @@
+import pytest
+from nl_sql_generator.worker_agent import _parse_pairs
+
+
+def test_parse_pairs_basic():
+    text = '{"question": "Q1", "answer": "A1"}\n{"question": "Q2", "answer": "A2"}'
+    pairs = _parse_pairs(text)
+    assert pairs == [
+        {"question": "Q1", "answer": "A1"},
+        {"question": "Q2", "answer": "A2"},
+    ]
+
+
+def test_parse_pairs_with_noise():
+    text = """Here you go:
+```json
+{"question": "Q1", "answer": "A1"}
+{"question": "Q2", "answer": "A2"}
+```
+- invalid
+"""
+    pairs = _parse_pairs(text)
+    assert pairs == [
+        {"question": "Q1", "answer": "A1"},
+        {"question": "Q2", "answer": "A2"},
+    ]


### PR DESCRIPTION
## Summary
- handle messy OpenAI output in worker_agent
- add helper `_parse_pairs` with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2f0e37a4832aa29041c4e9ca5a5b