### PR TITLE
Evenly distribute schema tables across workers

### DIFF
--- a/tests/test_parallel_schema_docs.py
+++ b/tests/test_parallel_schema_docs.py
@@ -23,3 +23,20 @@ def test_pool_dedup(monkeypatch):
     pairs = asyncio.run(pool.generate())
     assert len(pairs) == 5
     assert len({(p["question"], p["answer"]) for p in pairs}) == 5
+
+
+def test_schema_split(monkeypatch):
+    captured = []
+
+    class _Worker(DummyWorker):
+        def __init__(self, schema, cfg, validator_cls, wid, client):
+            captured.append(sorted(schema.keys()))
+            super().__init__(schema, cfg, validator_cls, wid, client)
+
+    monkeypatch.setattr(agent_pool, "WorkerAgent", _Worker)
+
+    schema = {f"t{i}": i for i in range(4)}
+    cfg = {"count": 2, "parallelism": 2}
+    pool = AgentPool(schema, cfg, lambda: None, None, None)
+    asyncio.run(pool.generate())
+    assert captured == [["t0", "t2"], ["t1", "t3"]]


### PR DESCRIPTION
## Summary
- distribute schema tables across workers in `AgentPool`
- test that tables are split amongst workers

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3a009cc4832a80b3173e800033c2