### PR TITLE
Fix correlation with UUID columns

### DIFF
--- a/tests/test_schema_relationship.py
+++ b/tests/test_schema_relationship.py
@@ -1,5 +1,6 @@
 import asyncio
 import pandas as pd
+import pytest
 from nl_sql_generator.schema_relationship import _analyze_pair, discover_relationships
 from nl_sql_generator.schema_loader import TableInfo, ColumnInfo
 
@@ -29,3 +30,11 @@ def test_discover_relationships(monkeypatch):
     engine = DummyEngine()
     pairs = asyncio.run(discover_relationships(schema, engine, n_rows=3, parallelism=1))
     assert {p["relationship"] for p in pairs} == {"t1.id -> t2.id"}
+
+
+def test_score_relation_uuid():
+    import uuid
+    from nl_sql_generator.schema_relationship import _score_relation
+
+    s = pd.Series([uuid.uuid4() for _ in range(5)])
+    assert _score_relation(s, s) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- cast non-numeric series to numeric codes before calculating correlation
- add unit test covering UUID columns

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c45a1ef00832a92ee3d8ec90042a4