### PR TITLE
Fix correlation warnings with constant series

### DIFF
--- a/nl_sql_generator/schema_relationship.py
+++ b/nl_sql_generator/schema_relationship.py
@@ -43,6 +43,10 @@ def _score_relation(series_a: pd.Series, series_b: pd.Series) -> float:
     df["a"] = _to_numeric(df["a"])
     df["b"] = _to_numeric(df["b"])
 
+    # avoid runtime warnings when series are constant
+    if df["a"].nunique() < 2 or df["b"].nunique() < 2:
+        return 0.0
+
     if Model is not None:
         try:  # pragma: no cover - best effort sempy usage
             m = Model("b ~ a")


### PR DESCRIPTION
## Summary
- avoid runtime warnings when computing correlations on constant series

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c47558ab8832aa2ae2d3c4a352bd6