### PR TITLE
Improve relationship discovery

### DIFF
--- a/nl_sql_generator/schema_relationship.py
+++ b/nl_sql_generator/schema_relationship.py
@@ -1,190 +1,200 @@
-"""Infer table relationships using sample rows."""
+"""Infer table relationships via explicit constraints and heuristics."""
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Any
 import asyncio
-import pandas as pd
-from pandas.api import types as ptypes
-from sqlalchemy import text
 import logging
+import os
+from difflib import SequenceMatcher
 
-try:  # optional sempy/semopy support
-    from semopy import Model
+import numpy as np
+from sqlalchemy import inspect, text
+
+try:  # optional openai support
+    import openai
 except Exception:  # pragma: no cover - optional dependency
-    Model = None
+    openai = None
 
 from .schema_loader import TableInfo
 
+__all__ = ["discover_relationships"]
+
 log = logging.getLogger(__name__)
 
+# ----------------------------------------------------------------------
+# helper functions
+# ----------------------------------------------------------------------
 
-async def _fetch_rows(engine, table: str, n_rows: int) -> pd.DataFrame:
-    """Return ``n_rows`` sample rows from ``table`` as a DataFrame."""
+def _name_similarity(a: str, b: str) -> float:
+    return SequenceMatcher(None, a.lower(), b.lower()).ratio()
 
-    log.info("Fetching %d rows from table %s", n_rows, table)
 
-    def _run() -> pd.DataFrame:
+def _same_type(t1: str, t2: str) -> bool:
+    def _base(t: str) -> str:
+        return t.split("(")[0].lower()
+
+    return _base(t1) == _base(t2)
+
+
+async def _comment_similarity(c1: str | None, c2: str | None) -> float:
+    """Return cosine similarity between ``c1`` and ``c2`` comments."""
+    if not c1 or not c2:
+        return 0.0
+    if openai is None or os.getenv("OPENAI_API_KEY") is None:
+        return 0.0
+
+    def _embed() -> tuple[np.ndarray, np.ndarray]:
+        client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        resp = client.embeddings.create(
+            model="text-embedding-3-small", input=[c1, c2]
+        )
+        e1 = np.array(resp.data[0].embedding, dtype=float)
+        e2 = np.array(resp.data[1].embedding, dtype=float)
+        return e1, e2
+
+    try:
+        emb1, emb2 = await asyncio.to_thread(_embed)
+    except Exception as err:  # pragma: no cover - network failures
+        log.warning("Embedding failed: %s", err)
+        return 0.0
+
+    denom = float(np.linalg.norm(emb1) * np.linalg.norm(emb2))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(emb1, emb2) / denom)
+
+
+async def _values_contained(
+    engine, t_from: str, c_from: str, t_to: str, c_to: str, limit: int
+) -> bool:
+    """Return ``True`` if sampled values from ``t_from.c_from`` mostly appear in ``t_to.c_to``."""
+
+    def _run() -> bool:
         with engine.connect() as conn:
-            res = conn.execute(text(f"SELECT * FROM {table} LIMIT {n_rows}"))
-            cols = list(res.keys())
-            rows = res.fetchall()
-        return pd.DataFrame([dict(zip(cols, r)) for r in rows])
-
-    df = await asyncio.to_thread(_run)
-    log.info("Fetched %d rows from table %s", len(df), table)
-    return df
-
-
-def _score_relation(series_a: pd.Series, series_b: pd.Series) -> float:
-    """Return similarity score between two columns."""
-
-    log.debug("Scoring relation between series of length %d and %d", len(series_a), len(series_b))
-    df = pd.DataFrame({"a": series_a, "b": series_b}).dropna()
-    if df.empty:
-        return 0.0
-
-    def _to_numeric(s: pd.Series) -> pd.Series:
-        if ptypes.is_numeric_dtype(s) or ptypes.is_bool_dtype(s):
-            return pd.to_numeric(s, errors="coerce")
-        return pd.Series(pd.factorize(s.astype(str))[0], index=s.index)
-
-    df["a"] = _to_numeric(df["a"])
-    df["b"] = _to_numeric(df["b"])
-
-    # avoid runtime warnings when series are constant
-    if df["a"].nunique() < 2 or df["b"].nunique() < 2:
-        return 0.0
-
-    if Model is not None:
-        try:  # pragma: no cover - best effort sempy usage
-            m = Model("b ~ a")
-            m.fit(df, quiet=True)
-            params = m.parameters_dict
-            val = params.get("l_b_a") or params.get("Beta") or 0.0
-            return abs(float(val))
-        except Exception:  # pragma: no cover - fallback
-            pass
-
-    corr = df["a"].corr(df["b"])
-    score = 0.0 if pd.isna(corr) else abs(float(corr))
-    log.debug("Correlation score: %.4f", score)
-    return score
-
-
-def _compatible_types(series_a: pd.Series, series_b: pd.Series) -> bool:
-    """Return ``True`` if series have comparable data types."""
-    if ptypes.is_numeric_dtype(series_a) and ptypes.is_numeric_dtype(series_b):
-        return True
-    if ptypes.is_bool_dtype(series_a) and ptypes.is_bool_dtype(series_b):
-        return True
-    if ptypes.is_datetime64_any_dtype(series_a) and ptypes.is_datetime64_any_dtype(series_b):
-        return True
-    if ptypes.is_string_dtype(series_a) and ptypes.is_string_dtype(series_b):
-        return True
-    return False
-
-
-def _matches_pk_name(pk: str, column: str, table: str) -> bool:
-    """Return ``True`` if ``column`` looks like a foreign key to ``pk``."""
-    col = column.lower()
-    pk = pk.lower()
-    table_base = table.rstrip("s").lower()
-    return col == pk or col == f"{table_base}_{pk}" or col.endswith(f"_{pk}")
-
-
-def _analyze_pair(
-    t1: str,
-    df1: pd.DataFrame,
-    t2: str,
-    df2: pd.DataFrame,
-    pk1: str | None = None,
-    pk2: str | None = None,
-) -> List[Dict[str, str]]:
-    """Return relationship records for ``t1`` and ``t2``."""
-    log.info("Analyzing table pair %s <-> %s", t1, t2)
-    relations: List[Dict[str, str]] = []
-    seen = set()
-    for c1 in df1.columns:
-        for c2 in df2.columns:
-            s1 = df1[c1]
-            s2 = df2[c2]
-            if not _compatible_types(s1, s2):
-                continue
-            score = _score_relation(s1, s2)
-            vals1 = set(s1.dropna())
-            vals2 = set(s2.dropna())
-            overlap = vals1 & vals2
-            ov_count = len(overlap)
-            ratio1 = ov_count / len(vals1) if vals1 else 0.0
-            ratio2 = ov_count / len(vals2) if vals2 else 0.0
-            log.debug(
-                "Pair %s.%s vs %s.%s score=%.4f overlap=%d ratio1=%.2f ratio2=%.2f",
-                t1,
-                c1,
-                t2,
-                c2,
-                score,
-                ov_count,
-                ratio1,
-                ratio2,
+            q1 = text(
+                f"SELECT DISTINCT {c_from} FROM {t_from} "
+                f"WHERE {c_from} IS NOT NULL LIMIT {limit}"
             )
-            base_condition = ov_count >= 2 and (score >= 0.9 or (ratio1 >= 0.5 and ratio2 >= 0.5))
-            pk_condition = False
-            if pk1 and c1 == pk1 and _matches_pk_name(pk1, c2, t1):
-                pk_condition = ov_count >= 2 and (ratio2 >= 0.5 or score >= 0.8)
-            if pk2 and c2 == pk2 and _matches_pk_name(pk2, c1, t2):
-                pk_condition = pk_condition or (ov_count >= 2 and (ratio1 >= 0.5 or score >= 0.8))
-            if base_condition or pk_condition:
-                rel = f"{t1}.{c1} -> {t2}.{c2}"
-                if rel not in seen:
-                    relations.append(
-                        {
-                            "question": f"How is {t1}.{c1} related to {t2}.{c2}?",
-                            "relationship": rel,
-                        }
-                    )
-                    seen.add(rel)
-    log.info("Found %d relationships between %s and %s", len(relations), t1, t2)
-    return relations
+            vals_a = {row[0] for row in conn.execute(q1)}
+            if not vals_a:
+                return False
+            q2 = text(
+                f"SELECT DISTINCT {c_to} FROM {t_to} WHERE {c_to} IS NOT NULL"
+            )
+            vals_b = {row[0] for row in conn.execute(q2)}
+        if not vals_a:
+            return False
+        matched = len([v for v in vals_a if v in vals_b])
+        return matched / len(vals_a) >= 0.95
 
+    try:
+        return await asyncio.to_thread(_run)
+    except Exception as err:  # pragma: no cover - DB errors
+        log.warning("Value check failed: %s", err)
+        return False
+
+
+# ----------------------------------------------------------------------
+# main logic
+# ----------------------------------------------------------------------
 
 async def discover_relationships(
-    schema: Dict[str, TableInfo],
-    engine,
-    n_rows: int = 5,
-    parallelism: int = 4,
-) -> List[Dict[str, str]]:
-    """Return relationship pairs extracted from the database."""
-    log.info(
-        "Discovering relationships using %d rows per table and parallelism=%d",
-        n_rows,
-        parallelism,
-    )
-    tables = list(schema.keys())
-    log.info("Fetching sample rows for %d tables", len(tables))
-    data = {tbl: await _fetch_rows(engine, tbl, n_rows) for tbl in tables}
+    schema: Dict[str, TableInfo], engine, sample_limit: int = 5000
+) -> List[Dict[str, Any]]:
+    """Return discovered relationships sorted by confidence."""
 
-    results: List[Dict[str, str]] = []
-    tasks = []
-    for i, t1 in enumerate(tables):
-        for t2 in tables[i + 1 :]:
-            df1 = data[t1]
-            df2 = data[t2]
-            log.info("Scheduling analysis for %s <-> %s", t1, t2)
-            pk1 = schema[t1].primary_key
-            pk2 = schema[t2].primary_key
-            tasks.append(asyncio.to_thread(_analyze_pair, t1, df1, t2, df2, pk1=pk1, pk2=pk2))
-            if len(tasks) >= parallelism:
-                n = len(tasks)
-                for rels in await asyncio.gather(*tasks):
-                    results.extend(rels)
-                log.info("Processed %d table pairs", n)
-                tasks = []
-    if tasks:
-        n = len(tasks)
-        for rels in await asyncio.gather(*tasks):
-            results.extend(rels)
-        log.info("Processed final %d table pairs", n)
-    log.info("Discovered %d relationships", len(results))
+    insp = inspect(engine)
+    results: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+
+    # ----------------------- step 1: explicit FKs ---------------------
+    for table in schema:
+        for fk in insp.get_foreign_keys(table):
+            rt = fk.get("referred_table")
+            lcols = fk.get("constrained_columns") or []
+            rcols = fk.get("referred_columns") or []
+            if not rt:
+                continue
+            for lc, rc in zip(lcols, rcols):
+                rel = f"{table}.{lc} -> {rt}.{rc}"
+                if rel in seen:
+                    continue
+                seen.add(rel)
+                results.append(
+                    {
+                        "question": f"How is {table}.{lc} related to {rt}.{rc}?",
+                        "relationship": rel,
+                        "confidence": 1.0,
+                    }
+                )
+
+    # gather PK/unique info for heuristic checks
+    pk_unique: Dict[str, set[str]] = {}
+    for tbl in schema:
+        pkc = insp.get_pk_constraint(tbl).get("constrained_columns") or []
+        uniq = []
+        for uc in insp.get_unique_constraints(tbl):
+            uniq.extend(uc.get("column_names", []))
+        for idx in insp.get_indexes(tbl):
+            if idx.get("unique"):
+                uniq.extend(idx.get("column_names", []))
+        pk_unique[tbl] = set(pkc + uniq)
+
+    # mapping of column info
+    type_map: Dict[tuple[str, str], str] = {}
+    comment_map: Dict[tuple[str, str], str | None] = {}
+    for t, info in schema.items():
+        for col in info.columns:
+            key = (t, col.name)
+            type_map[key] = col.type_
+            comment_map[key] = col.comment
+
+    # --------------------- steps 2-4 heuristics -----------------------
+    for ftbl, finfo in schema.items():
+        for fcol in finfo.columns:
+            ftype = type_map[(ftbl, fcol.name)]
+            fcomment = comment_map[(ftbl, fcol.name)]
+            for rtbl, _rinfo in schema.items():
+                if ftbl == rtbl:
+                    continue
+                for rcol in _rinfo.columns:
+                    if rcol.name not in pk_unique.get(rtbl, set()):
+                        continue
+                    rtype = type_map[(rtbl, rcol.name)]
+                    rcomment = comment_map[(rtbl, rcol.name)]
+                    if not _same_type(ftype, rtype):
+                        continue
+                    sim = max(
+                        _name_similarity(fcol.name, rcol.name),
+                        _name_similarity(fcol.name, f"{rtbl}_{rcol.name}"),
+                        _name_similarity(
+                            fcol.name, f"{rtbl.rstrip('s')}_{rcol.name}"
+                        ),
+                    )
+                    if sim < 0.8:
+                        continue
+                    conf = 0.75
+                    com_sim = await _comment_similarity(fcomment, rcomment)
+                    if com_sim >= 0.83:
+                        conf += 0.1
+                    if await _values_contained(
+                        engine, ftbl, fcol.name, rtbl, rcol.name, sample_limit
+                    ):
+                        conf += 0.1
+                    if conf >= 0.75:
+                        rel = f"{ftbl}.{fcol.name} -> {rtbl}.{rcol.name}"
+                        if rel in seen:
+                            continue
+                        seen.add(rel)
+                        results.append(
+                            {
+                                "question": f"How is {ftbl}.{fcol.name} related to {rtbl}.{rcol.name}?",
+                                "relationship": rel,
+                                "confidence": round(conf, 2),
+                            }
+                        )
+
+    results.sort(key=lambda r: r["confidence"], reverse=True)
     return results
+


### PR DESCRIPTION
## Summary
- rewrite `schema_relationship` to use FK metadata, column naming/PK heuristics, comment embeddings and sampled value checks
- adjust tests for the new algorithm

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5600c580832ab71dedee1ada5c96