### PR TITLE
Add run_version argument and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ export DATABASE_URL="postgresql://user:pass@host:5432/db"
 export OPENAI_API_KEY="sk-..."
 
 # generate via CLI (tasks come from config.yaml)
-python -m nl_sql_generator.main gen --config config.yaml
+python -m nl_sql_generator.main gen --config config.yaml --run-version v1
 # run a single phase only
-# python -m nl_sql_generator.main gen --config config.yaml --phase joins
+# python -m nl_sql_generator.main gen --config config.yaml --phase joins --run-version v1
 # no separate questions file is needed
 
 # or from Python
@@ -107,7 +107,8 @@ This phase automatically discovers how tables relate to each other. It pulls
 sample rows from every table, analyses column pairs for overlap and correlation
 and then prompts the LLM using the `schema_relationship_template.txt` prompt.
 The generated question/relationship pairs are written to
-`generated_datasets/schema_relationship/dataset.jsonl` and can be invoked via
+`generated_datasets/schema_relationship/dataset_<run_version>.jsonl` (or
+`dataset.jsonl` if no version is provided) and can be invoked via
 `--phase schema_relationship` when running the CLI.
 
 ## Running tests

--- a/nl_sql_generator/main.py
+++ b/nl_sql_generator/main.py
@@ -77,6 +77,7 @@ def cli() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--config", default="config.yaml")
     p.add_argument("--phase", default=None)
+    p.add_argument("--run-version", default=None)
     args = p.parse_args()
 
     if not args.config.lower().endswith((".yaml", ".yml")):
@@ -94,7 +95,7 @@ def cli() -> None:
         writer=ResultWriter(),
     )
     tasks = load_tasks(args.config, schema, phase=args.phase)
-    for res in job.run_tasks(tasks):
+    for res in job.run_tasks(tasks, run_version=args.run_version):
         log.info(json.dumps({"question": res.question, "sql": res.sql}))
 
 
@@ -103,6 +104,7 @@ def gen(
     config: str = "config.yaml",
     stream: bool = False,
     phase: str | None = None,
+    run_version: str | None = None,
 ) -> None:
     """Generate SQL and result rows for tasks defined in ``config``.
 
@@ -110,6 +112,7 @@ def gen(
         config: Path to configuration YAML.
         stream: Unused placeholder for streaming.
         phase: Optional phase name to filter tasks.
+        run_version: String appended to dataset file names.
     """
 
     if not config.lower().endswith((".yaml", ".yml")):
@@ -128,7 +131,7 @@ def gen(
     )
 
     tasks = load_tasks(config, schema, phase=phase)
-    results = job.run_tasks(tasks)
+    results = job.run_tasks(tasks, run_version=run_version)
     for r in results:
         typer.echo(json.dumps({"question": r.question, "sql": r.sql, "rows": r.rows}))
 


### PR DESCRIPTION
## Summary
- allow passing run_version to main commands
- append run_version to dataset file names and overwrite on new run
- document CLI usage with run_version
- test overwriting behaviour

## Testing
- `black --line-length 100 .`
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c58a1766c832a8880b179a322901a