### PR TITLE
Improve relationship discovery using table comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ config.yaml ──▶ InputLoader ──▶ AutonomousJob
 ## Schema relationship phase
 
 This phase automatically discovers how tables relate to each other. It now logs
-each step and combines explicit foreign keys with heuristics based on column
-names, comments and sample row overlap. Column comments are compared using
-embeddings and sampled data is inspected for inclusion dependencies. The
-generated question/relationship pairs are written to
+each step and combines explicit foreign keys with heuristics based on column and
+table comments, column names and sample row overlap. Comments are fetched from
+the database DDL, compared using embeddings and sampled data is inspected for
+inclusion dependencies. The generated question/relationship pairs are written to
 `generated_datasets/schema_relationship/dataset_<run_version>.jsonl` (or
 `dataset.jsonl` if no version is provided) and can be invoked via
 `--phase schema_relationship` when running the CLI. Each dataset entry contains

--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nl_sql_generator.schema_loader import SchemaLoader
+
+
+class DummyInspector:
+    def __init__(self):
+        pass
+
+    def get_table_names(self):
+        return ["tbl"]
+
+    def get_columns(self, table):
+        return [{"name": "id", "type": "int", "comment": "pk"}]
+
+    def get_pk_constraint(self, table):
+        return {"constrained_columns": ["id"]}
+
+    def get_table_comment(self, table):
+        return {"text": "tbl comment"}
+
+
+class DummyEngine:
+    pass
+
+
+def test_load_schema_with_comments(monkeypatch):
+    inspector = DummyInspector()
+    monkeypatch.setattr(
+        "nl_sql_generator.schema_loader.create_engine", lambda u, pool_pre_ping=True: DummyEngine()
+    )
+    monkeypatch.setattr("nl_sql_generator.schema_loader.inspect", lambda e: inspector)
+
+    os.environ["DATABASE_URL"] = "pg://x"
+    schema = SchemaLoader.load_schema()
+    info = schema["tbl"]
+    assert info.comment == "tbl comment"
+    assert info.columns[0].comment == "pk"


### PR DESCRIPTION
## Summary
- fetch table comments during schema loading
- use table comments during relationship discovery
- log the schema load steps
- test table comments and updated relationship logic
- document improved relationship detection

## Testing
- `ruff check --fix nl_sql_generator tests`
- `black nl_sql_generator/schema_loader.py nl_sql_generator/schema_relationship.py tests/test_schema_loader.py tests/test_schema_relationship.py --line-length 100`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c60bf05c0832a8a24f20e2b39e6b8