### PR TITLE
Handle whitespace in DATABASE_URL

### DIFF
--- a/nl_sql_generator/schema_loader.py
+++ b/nl_sql_generator/schema_loader.py
@@ -70,7 +70,8 @@ class SchemaLoader:
         Raises:
             ValueError: If no database URL is provided.
         """
-        db_url = db_url or os.getenv("DATABASE_URL")
+        # Trim whitespace so extraneous newlines don't break authentication
+        db_url = (db_url or os.getenv("DATABASE_URL", "")).strip()
         if not db_url:
             raise ValueError("Provide DATABASE_URL env var or param")
 

--- a/nl_sql_generator/sql_validator.py
+++ b/nl_sql_generator/sql_validator.py
@@ -30,7 +30,9 @@ class SQLValidator:
             ValueError: If no database URL is provided.
         """
 
-        self.db_url = db_url or os.getenv("DATABASE_URL")
+        # Strip whitespace to avoid connection issues when env vars contain
+        # trailing newlines or spaces.
+        self.db_url = (db_url or os.getenv("DATABASE_URL", "")).strip()
         if not self.db_url:
             raise ValueError("DATABASE_URL not set")
         self.eng = create_engine(

--- a/nl_sql_generator/writer.py
+++ b/nl_sql_generator/writer.py
@@ -34,7 +34,9 @@ class ResultWriter:
             ValueError: If no database URL can be determined.
         """
 
-        db_url = db_url or os.getenv("DATABASE_URL")
+        # Environment variables may include trailing newlines when sourced from
+        # files or CI secrets. Strip whitespace to avoid authentication errors.
+        db_url = (db_url or os.getenv("DATABASE_URL", "")).strip()
         if not db_url:
             raise ValueError("DATABASE_URL not set")
         self.eng = create_engine(db_url, pool_pre_ping=True, connect_args={"sslmode": "require"})


### PR DESCRIPTION
## Summary
- trim whitespace from DATABASE_URL before creating SQLAlchemy engine
- update SchemaLoader, SQLValidator and ResultWriter to strip env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c731650c4832a8df282fc0b1d1132