### PR TITLE
Handle validator exceptions

### DIFF
--- a/nl_sql_generator/schema_relationship.py
+++ b/nl_sql_generator/schema_relationship.py
@@ -329,8 +329,13 @@ async def discover_relationships(
         sql = f"SELECT 1 FROM {ftbl} a JOIN {rtbl} b ON a.{fcol.name} = b.{pk} LIMIT 1"
         validator_ok = True
         if validator:
-            validator_ok, _ = await asyncio.to_thread(validator.check, sql)
-            log.info("Validation of relationship SQL '%s': %s", sql, validator_ok)
+            try:
+                validator_ok, _ = await asyncio.to_thread(validator.check, sql)
+            except Exception as err:  # pragma: no cover - unexpected errors
+                log.exception("Validation check failed: %s", err)
+                validator_ok = False
+            else:
+                log.info("Validation of relationship SQL '%s': %s", sql, validator_ok)
         else:
             log.info("Validation skipped for SQL '%s'", sql)
         if not validator_ok:


### PR DESCRIPTION
## Summary
- avoid crashing on SQLValidator errors in schema_relationship

## Testing
- `black --line-length 100 nl_sql_generator/schema_relationship.py`
- `ruff check --fix nl_sql_generator/schema_relationship.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7b6fe074832a8726d10c3f798627