### PR TITLE
Improve builtins phase prompts and validation

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -4,7 +4,8 @@ phases:
   - name: builtins
     count: 5
     builtins: [COUNT, SUM, AVG, MIN, MAX, COALESCE, NULLIF, CONCAT, LENGTH, SUBSTRING, LOWER, UPPER, TRIM, REPLACE, EXTRACT, DATE_TRUNC, NOW, CURRENT_DATE, CURRENT_TIMESTAMP, AGE, TO_CHAR, ROUND, CEIL, FLOOR, MOD, ABS, ROW_NUMBER, RANK, LAG, LEAD]
-    use_sample_rows: false
+    prompt_template: builtin_sql_template.txt
+    use_sample_rows: true
     dataset_output_file_dir: generated_datasets/builtins
 
   - name: schema_docs

--- a/nl_sql_generator/prompt_template/builtin_sql_template.txt
+++ b/nl_sql_generator/prompt_template/builtin_sql_template.txt
@@ -1,0 +1,8 @@
+### role: system
+You are a PostgreSQL expert. Given the database schema in JSON format, generate a SQL query answering the user's question. Ensure the query uses the `{{builtin}}` function. You may call the `writer` tool to inspect sample rows if needed. Return only the SQL.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}
+
+{{nl_question}}

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from nl_sql_generator.sql_validator import SQLValidator
+
+
+class _FakeConn:
+    def execute(self, sql):
+        if "FAIL" in str(sql):
+            raise Exception("boom")
+        return []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class _FakeEngine:
+    def connect(self):
+        return _FakeConn()
+
+
+def test_validator_success():
+    v = SQLValidator.__new__(SQLValidator)
+    v.eng = _FakeEngine()
+    ok, err = v.check("SELECT 1")
+    assert ok and err is None
+
+
+def test_validator_failure():
+    v = SQLValidator.__new__(SQLValidator)
+    v.eng = _FakeEngine()
+    ok, err = v.check("FAIL")
+    assert not ok


### PR DESCRIPTION
## Summary
- add builtins prompt template
- let builtins phase use the template and writer tool
- support extra variables in `load_template_messages`
- validate final SQL results in `AutonomousJob`
- validate queries by running them in `SQLValidator`
- cover validator logic with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cffea4008832a866366c1f3ff2f84