### PR TITLE
Handle SQL validation failures gracefully

### DIFF
--- a/nl_sql_generator/prompt_template/builtin_sql_template.txt
+++ b/nl_sql_generator/prompt_template/builtin_sql_template.txt
@@ -1,8 +1,11 @@
 ### role: system
-You are a PostgreSQL expert. Given the database schema in JSON format, generate a SQL query answering the user's question. Ensure the query uses the `{{builtin}}` function. You may call the `writer` tool to inspect sample rows if needed. Return only the SQL.
+You are a PostgreSQL expert. Given the database schema in JSON format, generate a SQL query answering the user's question. Ensure the query uses the `{{builtin}}` function. Use the sample rows to understand the columns. Return only the SQL.
 
 ### role: user
 SCHEMA_JSON:
 {{schema_json}}
+
+SAMPLE_ROWS:
+{{sample_rows}}
 
 {{nl_question}}

--- a/tests/test_validation_failure.py
+++ b/tests/test_validation_failure.py
@@ -1,0 +1,25 @@
+import os, sys, asyncio
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from nl_sql_generator.autonomous_job import AutonomousJob
+
+class DummyClient:
+    def remaining_budget(self):
+        return 1.0
+
+    async def arun_jobs(self, *_, **__):
+        return [{"role": "assistant", "content": '{"sql": "SELECT 1"}'}]
+
+class FailingValidator:
+    def check(self, sql):
+        return False, "bad"
+
+class DummyWriter:
+    def fetch(self, *a, **k):
+        return []
+    def append_jsonl(self, *a, **k):
+        pass
+
+def test_run_task_handles_validation_failure():
+    job = AutonomousJob({}, client=DummyClient(), validator=FailingValidator(), writer=DummyWriter(), critic=None)
+    result = asyncio.run(job.run_task({"phase": "demo", "question": "q", "metadata": {}}))
+    assert result.sql == "FAIL"


### PR DESCRIPTION
## Summary
- ensure validator failures return a `FAIL` SQL status instead of raising
- supply targeted schema & sample rows for SQL generation
- add concurrency to run_tasks via async runners
- lock dataset writing across async tasks
- update builtin prompt template to include sample rows
- test validation failure case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d066bd884832a8c7f79117d540cb1