### PR TITLE
Add NL question+SQL generation for builtins

### DIFF
--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -18,21 +18,14 @@ import yaml
 
 
 def _natural_builtin_question(fn: str, table: str) -> str:
-    """Return a natural language question for ``fn`` and ``table``."""
+    """Return an instruction asking the LLM to create a question and SQL."""
 
     fn = fn.upper()
     table = table.replace("_", " ")
-    specific = {
-        "COUNT": f"Using the COUNT function, get the total number of rows in the {table} table.",
-    }
-    if fn in specific:
-        return specific[fn]
-    templates = [
-        "Using the {fn} function, show an example query on the {table} table.",
-        "Use {fn} to retrieve information from the {table} table.",
-        "Show how to apply {fn} on the {table} table.",
-    ]
-    return random.choice(templates).format(fn=fn, table=table)
+    return (
+        f"Create a natural language question about the {table} table that uses the {fn} function."
+        " Then provide the SQL query answering it as JSON with keys 'question' and 'sql'."
+    )
 
 
 class NLTask(TypedDict):
@@ -143,7 +136,7 @@ def load_tasks(
                         random.choice(table_names) if table_names else f"table_{i + 1}"
                     )
                     q = _natural_builtin_question(fn, table)
-                    meta_with_fn = {**meta, "builtins": [fn]}
+                    meta_with_fn = {**meta, "builtins": [fn], "table": table}
                     tasks.append(
                         {"phase": name, "question": q, "metadata": meta_with_fn}
                     )
@@ -157,7 +150,7 @@ def load_tasks(
                         random.choice(table_names) if table_names else f"table_{i + 1}"
                     )
                     q = _natural_builtin_question(fn, table)
-                    meta_with_fn = {**meta, "builtins": [fn]}
+                    meta_with_fn = {**meta, "builtins": [fn], "table": table}
                     tasks.append(
                         {"phase": name, "question": q, "metadata": meta_with_fn}
                     )
@@ -168,6 +161,7 @@ def load_tasks(
             builtin = random.choice(builtins) if builtins else "COUNT"
             table = random.choice(table_names) if table_names else f"table_{i + 1}"
             q = _natural_builtin_question(builtin, table)
-            tasks.append({"phase": name, "question": q, "metadata": meta})
+            meta_with_fn = {**meta, "builtins": [builtin], "table": table}
+            tasks.append({"phase": name, "question": q, "metadata": meta_with_fn})
 
     return tasks

--- a/nl_sql_generator/prompt_builder.py
+++ b/nl_sql_generator/prompt_builder.py
@@ -111,6 +111,9 @@ def build_prompt(
         builtin = phase_cfg.get("builtins", [None])[0]
         if builtin:
             extra["builtin"] = builtin
+        table = phase_cfg.get("table")
+        if table:
+            extra["table"] = table
         if "sample_rows" in phase_cfg:
             extra["sample_rows"] = phase_cfg["sample_rows"]
         return load_template_messages(template_name, schema, nl_question, extra)

--- a/nl_sql_generator/prompt_template/builtin_sql_template.txt
+++ b/nl_sql_generator/prompt_template/builtin_sql_template.txt
@@ -1,5 +1,5 @@
 ### role: system
-You are a PostgreSQL expert. Given the database schema in JSON format, generate a SQL query answering the user's question. Ensure the query uses the `{{builtin}}` function. Use the sample rows to understand the columns. Return only the SQL.
+You are a PostgreSQL expert. Craft a natural language question about the data that requires the `{{builtin}}` function. Then provide the SQL query that answers the question. Use the schema and sample rows for context. Respond with a JSON object containing ``question`` and ``sql`` only.
 
 ### role: user
 SCHEMA_JSON:


### PR DESCRIPTION
## Summary
- revise builtin prompt to return `question`/`sql` JSON
- allow `table` in prompt extras
- generate builtin tasks with table metadata
- return question from tool-generated SQL
- adjust agent system message for builtins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d097817bc832a97b79f6c4db1a189