### PR TITLE
Fix _truncate_schema_lines handling of None

### DIFF
--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -62,8 +62,14 @@ def _estimate_cost(input_tokens: int, output_tokens: int, model: str) -> float:
     return input_tokens * in_rate + output_tokens * out_rate
 
 
-def _truncate_schema_lines(text: str) -> str:
-    """Return ``text`` with schema details removed for logging purposes."""
+def _truncate_schema_lines(text: str | None) -> str:
+    """Return ``text`` with schema details removed for logging purposes.
+
+    ``None`` inputs are treated as an empty string.
+    """
+    if not text:
+        return ""
+
     lower_text = text.lower()
 
     # Handle ``SCHEMA_JSON:`` blocks by keeping only table names


### PR DESCRIPTION
## Summary
- guard `_truncate_schema_lines` against `None` inputs
- this prevents an `AttributeError` when logging prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0e560df4832aab519899ba56add1