### PR TITLE
Improve single_table dataset generation

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -19,6 +19,7 @@ phases:
   - name: single_table
     count: 30
     use_sample_rows: true
+    prompt_template: single_table_sql_template.txt
     dataset_output_file_dir: generated_datasets/single_table
 
   - name: joins

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -28,6 +28,16 @@ def _natural_builtin_question(fn: str, table: str) -> str:
     )
 
 
+def _natural_table_question(table: str) -> str:
+    """Return an instruction asking the LLM to craft NL/SQL for one table."""
+
+    table = table.replace("_", " ")
+    return (
+        f"Create a natural language question about the {table} table."
+        " Then provide the SQL query answering it as JSON with keys 'question' and 'sql'."
+    )
+
+
 class NLTask(TypedDict):
     """A single natural-language question with context.
 
@@ -112,6 +122,14 @@ def load_tasks(
             n_rows = int(phase_def.get("n_rows", 5))
             meta_with_rows = {**meta, "n_rows": n_rows}
             tasks.append({"phase": name, "question": q, "metadata": meta_with_rows})
+            continue
+        if name.lower() == "single_table":
+            count = int(phase_def.get("count", 1))
+            for tbl in table_names or ["table_1"]:
+                for _ in range(count):
+                    q = _natural_table_question(tbl)
+                    meta_with_tbl = {**meta, "table": tbl}
+                    tasks.append({"phase": name, "question": q, "metadata": meta_with_tbl})
             continue
         questions = phase_def.get("questions")
         if questions:

--- a/nl_sql_generator/prompt_template/single_table_sql_template.txt
+++ b/nl_sql_generator/prompt_template/single_table_sql_template.txt
@@ -1,0 +1,11 @@
+### role: system
+You are a PostgreSQL expert. Craft a natural language question about the `{{table}}` table using only columns from that table. Use the schema and sample rows for context. Respond with a JSON object containing "question" and "sql" only.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}
+
+SAMPLE_ROWS:
+{{sample_rows}}
+
+{{nl_question}}

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -154,3 +154,22 @@ phases:
     assert len(tasks) == 1
     assert tasks[0]["phase"] == "schema_relationship"
     assert tasks[0]["metadata"]["n_rows"] == 4
+
+
+def test_single_table_phase(tmp_path):
+    cfg = """
+phases:
+  - name: single_table
+    count: 2
+    prompt_template: single_table_sql_template.txt
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    schema = {"a": object(), "b": object()}
+    tasks = load_tasks(str(path), schema)
+
+    # two tables * count 2 each
+    assert len(tasks) == 4
+    assert {t["metadata"]["table"] for t in tasks} == {"a", "b"}
+    assert all(t["metadata"]["prompt_template"] == "single_table_sql_template.txt" for t in tasks)


### PR DESCRIPTION
## Summary
- support single_table phase tasks in input_loader
- template-driven prompting for single_table examples
- update config to reference the new template
- add test coverage for single_table phase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d16aa8568832a8613f9f5faadc82d