### PR TITLE
Improve single_table handling

### DIFF
--- a/nl_sql_generator/agent_pool.py
+++ b/nl_sql_generator/agent_pool.py
@@ -47,8 +47,9 @@ class AgentPool:
         if not table_names:
             return [self.schema]
         n = min(n, len(table_names))
-        chunks = [table_names[i::n] for i in range(n)]
-        return [{t: self.schema[t] for t in c} for c in chunks]
+        return [
+            {table_names[i]: self.schema[table_names[i]]} for i in range(n)
+        ]
 
     async def _run_worker(
         self, batch_size: int, worker_id: int, schema: Dict[str, Any]

--- a/nl_sql_generator/writer.py
+++ b/nl_sql_generator/writer.py
@@ -103,9 +103,9 @@ class ResultWriter:
         if isinstance(value, (int, float)):
             return value
         if isinstance(value, datetime.datetime):
-            return self.fake.date_time_this_decade()
+            return self.fake.date_time_this_decade().isoformat(sep=" ")
         if isinstance(value, datetime.date):
-            return self.fake.date_this_decade()
+            return self.fake.date_this_decade().isoformat()
         if isinstance(value, datetime.time):
             return self.fake.time()
         if isinstance(value, str):

--- a/tests/test_parallel_schema_docs.py
+++ b/tests/test_parallel_schema_docs.py
@@ -39,4 +39,4 @@ def test_schema_split(monkeypatch):
     cfg = {"count": 2, "parallelism": 2}
     pool = AgentPool(schema, cfg, lambda: None, None, None)
     asyncio.run(pool.generate())
-    assert captured == [["t0", "t2"], ["t1", "t3"]]
+    assert captured == [["t0"], ["t1"]]

--- a/tests/test_validation_failure.py
+++ b/tests/test_validation_failure.py
@@ -1,4 +1,6 @@
-import os, sys, asyncio
+import asyncio
+import os
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from nl_sql_generator.autonomous_job import AutonomousJob
 


### PR DESCRIPTION
## Summary
- ensure date values in rows are JSON serialisable
- skip invalid SQL pairs for all phases and deduplicate single-table SQL
- respect max parallelism via env override and show progress
- allocate one table per worker
- adjust tests for new worker chunking

## Testing
- `ruff check nl_sql_generator tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1a44022c832ab13167e4f7a4e091