### PR TITLE
Improve single_table prompt generation

### DIFF
--- a/nl_sql_generator/prompt_template/single_table_sql_template.txt
+++ b/nl_sql_generator/prompt_template/single_table_sql_template.txt
@@ -1,5 +1,5 @@
 ### role: system
-You are a PostgreSQL expert. Craft a natural language question about the `{{table}}` table using only columns from that table. Use the schema and sample rows for context. Respond with a JSON object containing "question" and "sql" only.
+You are a PostgreSQL expert. Craft {{count}} unique natural language questions about the `{{table}}` table using only columns from that table. Use the schema and sample rows for context. Respond with one JSON object per line containing "question" and "sql" only.
 
 ### role: user
 SCHEMA_JSON:

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -169,7 +169,9 @@ phases:
     schema = {"a": object(), "b": object()}
     tasks = load_tasks(str(path), schema)
 
-    # two tables * count 2 each
-    assert len(tasks) == 4
+    # one task per table with count metadata
+    assert len(tasks) == 2
     assert {t["metadata"]["table"] for t in tasks} == {"a", "b"}
+    assert all(t["metadata"]["count"] == 2 for t in tasks)
+    assert all(t["metadata"]["parallelism"] == 2 for t in tasks)
     assert all(t["metadata"]["prompt_template"] == "single_table_sql_template.txt" for t in tasks)

--- a/tests/test_run_tasks.py
+++ b/tests/test_run_tasks.py
@@ -129,3 +129,28 @@ def test_deduplicate_pairs(tmp_path):
     }
     job.run_tasks([t, t])
     assert writer.seen == [{"question": "same?", "sql": "SELECT 1"}]
+
+
+def test_single_table_multiple_pairs(tmp_path):
+    writer = DummyWriter()
+    job = AutonomousJob(
+        {}, writer=writer, client=DummyClient(), validator=DummyValidator(), critic=None
+    )
+
+    async def _rt(t):
+        return JobResult("", "", [
+            {"question": "Q1", "sql": "S1"},
+            {"question": "Q2", "sql": "S2"},
+        ])
+
+    job.run_task = _rt
+    t = {
+        "phase": "single_table",
+        "question": "",
+        "metadata": {"dataset_output_file_dir": str(tmp_path)},
+    }
+    job.run_tasks([t])
+    assert writer.seen == [
+        {"question": "Q1", "sql": "S1"},
+        {"question": "Q2", "sql": "S2"},
+    ]


### PR DESCRIPTION
## Summary
- generate a single_table task per table and run them in parallel
- update prompt template to create multiple NL/SQL pairs
- implement `_run_single_table_async` and integrate with dataset writer
- adjust input loader and tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d20049ef4832a9e046a7005201d69