### PR TITLE
Add usage logging and SQL execution for single_table phase

### DIFF
--- a/nl_sql_generator/openai_responses.py
+++ b/nl_sql_generator/openai_responses.py
@@ -143,6 +143,7 @@ class ResponsesClient:
         self.tokens_in = 0
         self.tokens_out = 0
         self.cost_spent = 0.0
+        self.request_count = 0
         self.usage = Usage()
 
         api_key = os.getenv("OPENAI_API_KEY")
@@ -317,6 +318,7 @@ class ResponsesClient:
                     self.tokens_out += out_tok
                     self.cost_spent += est_cost
                     self.usage.add(in_tok, out_tok, est_cost)
+                    self.request_count += 1
                 log.info(
                     "OpenAI response: in=%d out=%d cost=$%.4f budget_left=$%.4f",
                     in_tok,


### PR DESCRIPTION
## Summary
- log number of tokens and API calls after running tasks
- execute each single_table query on Postgres and validate
- track request count in `ResponsesClient`

## Testing
- `pip install pyyaml faker SQLAlchemy openai rich numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2626e864832a80d4711ff6222a11