### PR TITLE
Implement joins phase with validation loop

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -26,6 +26,7 @@ phases:
     count: 25
     examples_file: fewshot/multi_table_examples.yaml
     use_sample_rows: false
+    min_joins: 2
     dataset_output_file_dir: generated_datasets/joins
 
   - name: sample_data

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -141,6 +141,18 @@ def load_tasks(
                 }
                 tasks.append({"phase": name, "question": q, "metadata": meta_with_tbl})
             continue
+        if name.lower() == "joins":
+            count = int(phase_def.get("count", 1))
+            min_joins = int(phase_def.get("min_joins", 2))
+            q = str(
+                phase_def.get(
+                    "question",
+                    f"Generate {count} question/SQL pairs requiring joins.",
+                )
+            )
+            meta_with_count = {**meta, "count": count, "min_joins": min_joins}
+            tasks.append({"phase": name, "question": q, "metadata": meta_with_count})
+            continue
         questions = phase_def.get("questions")
         if questions:
             for q in questions:

--- a/nl_sql_generator/join_pool.py
+++ b/nl_sql_generator/join_pool.py
@@ -1,0 +1,80 @@
+"""Orchestrate JoinWorker agents in parallel."""
+
+import asyncio
+import math
+import random
+import itertools
+import logging
+from typing import Any, Dict, List
+
+from .join_worker import JoinWorker
+from .openai_responses import ResponsesClient
+
+
+class JoinPool:
+    def __init__(self, schema: Dict[str, Any], phase_cfg: Dict[str, Any], validator_cls, writer, critic, client: ResponsesClient) -> None:
+        self.schema = schema
+        self.cfg = phase_cfg
+        self.validator_cls = validator_cls
+        self.writer = writer
+        self.critic = critic
+        self.client = client
+        self.seen: set[tuple[str, str]] = set()
+        self.lock = asyncio.Lock()
+        self.log = logging.getLogger(__name__)
+
+    def _schema_chunks(self) -> List[Dict[str, Any]]:
+        n = int(self.cfg.get("parallelism", 1))
+        min_joins = int(self.cfg.get("min_joins", 2))
+        table_names = list(self.schema.keys())
+        if not table_names:
+            return [self.schema]
+        chunks: List[Dict[str, Any]] = []
+        for _ in range(min(n, len(table_names))):
+            k = min(len(table_names), max(min_joins, 2))
+            chosen = random.sample(table_names, k=k)
+            chunks.append({t: self.schema[t] for t in chosen})
+        return chunks
+
+    async def _run_worker(self, batch_size: int, worker_id: int, schema_subset: Dict[str, Any]) -> int:
+        cfg = dict(self.cfg)
+        if cfg.get("use_sample_rows"):
+            n_rows = int(cfg.get("n_rows", 5))
+            sample_rows = {}
+            for t in schema_subset:
+                try:
+                    sample_rows[t] = self.writer.fetch(f"SELECT * FROM {t} LIMIT {n_rows}", n_rows)
+                except Exception as err:
+                    self.log.warning("Worker %d failed fetching rows for %s: %s", worker_id, t, err)
+            if sample_rows:
+                cfg["sample_rows"] = sample_rows
+        self.log.info("Worker %d starting batch size %d", worker_id, batch_size)
+        agent = JoinWorker(schema_subset, cfg, self.validator_cls, self.critic, self.writer, worker_id, self.client)
+        pairs = await agent.generate(batch_size)
+        async with self.lock:
+            before = len(self.seen)
+            for p in pairs:
+                self.seen.add((p["question"], p["sql"]))
+            delta = len(self.seen) - before
+        self.log.info("Worker %d produced %d new pairs", worker_id, delta)
+        return delta
+
+    async def generate(self) -> List[Dict[str, str]]:
+        goal = int(self.cfg.get("count", 1))
+        schema_chunks = self._schema_chunks()
+        n_workers = len(schema_chunks)
+        k = math.ceil(goal / max(n_workers, 1))
+        attempts = 0
+        self.log.info(
+            "Starting join generation: goal=%d parallelism=%d batch_size=%d",
+            goal,
+            n_workers,
+            k,
+        )
+        while len(self.seen) < goal and attempts < self.cfg.get("max_attempts", 6):
+            jobs = [self._run_worker(k, i, schema_chunks[i]) for i in range(n_workers)]
+            await asyncio.gather(*jobs)
+            attempts += 1
+            self.log.info("Attempt %d complete, total pairs=%d", attempts, len(self.seen))
+        self.log.info("Join generation finished with %d pairs", len(self.seen))
+        return [{"question": q, "sql": s} for q, s in itertools.islice(self.seen, goal)]

--- a/nl_sql_generator/join_worker.py
+++ b/nl_sql_generator/join_worker.py
@@ -1,0 +1,54 @@
+import logging
+import json
+from typing import Any, Dict, List
+from .openai_responses import ResponsesClient
+from .prompt_builder import load_template_messages, _schema_as_markdown
+from .worker_agent import _parse_pairs
+
+log = logging.getLogger(__name__)
+
+class JoinWorker:
+    def __init__(self, schema: Dict[str, Any], cfg: Dict[str, Any], validator_cls, critic, writer, wid: int, client: ResponsesClient) -> None:
+        self.schema = schema
+        self.cfg = cfg
+        self.validator = validator_cls()
+        self.critic = critic
+        self.writer = writer
+        self.wid = wid
+        self.client = client
+
+    async def generate(self, k: int) -> List[Dict[str, str]]:
+        log.info("Worker %d generating %d join pairs", self.wid, k)
+        extra = {
+            "count": k,
+            "min_joins": self.cfg.get("min_joins", 2),
+        }
+        if "sample_rows" in self.cfg:
+            extra["sample_rows"] = self.cfg["sample_rows"]
+        messages = load_template_messages("join_sql_template.txt", self.schema, "", extra)
+        completion = await self.client.acomplete(messages)
+        pairs = _parse_pairs(completion)
+        results: List[Dict[str, str]] = []
+        for p in pairs:
+            q = p.get("question", "")
+            sql = p.get("sql", "")
+            attempts = 0
+            while attempts <= 2:
+                ok, err = self.validator.check(sql)
+                if ok:
+                    break
+                log.warning("Worker %d validation failed: %s", self.wid, err)
+                if attempts >= 2:
+                    sql = None
+                    break
+                fix = await self.critic.areview(q, sql, _schema_as_markdown(self.schema))
+                sql = fix.get("fixed_sql", sql)
+                attempts += 1
+            if sql and ok:
+                try:
+                    self.writer.fetch(sql, int(self.cfg.get("n_rows", 5)))
+                    results.append({"question": q, "sql": sql})
+                except Exception as err:
+                    log.warning("Worker %d execution failed: %s", self.wid, err)
+        log.info("Worker %d produced %d valid pairs", self.wid, len(results))
+        return results

--- a/nl_sql_generator/prompt_template/join_sql_template.txt
+++ b/nl_sql_generator/prompt_template/join_sql_template.txt
@@ -1,0 +1,11 @@
+### role: system
+You are a PostgreSQL expert. Craft {{count}} unique natural language questions that require joining at least {{min_joins}} tables using only the provided schema and sample rows if available. Return one JSON object per line with keys "question" and "sql" only.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}
+
+SAMPLE_ROWS:
+{{sample_rows}}
+
+{{nl_question}}

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -175,3 +175,20 @@ phases:
     assert all(t["metadata"]["count"] == 2 for t in tasks)
     assert all(t["metadata"]["parallelism"] == 2 for t in tasks)
     assert all(t["metadata"]["prompt_template"] == "single_table_sql_template.txt" for t in tasks)
+
+
+def test_joins_phase(tmp_path):
+    cfg = """
+phases:
+  - name: joins
+    count: 5
+    min_joins: 3
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"a": object(), "b": object()})
+    assert len(tasks) == 1
+    meta = tasks[0]["metadata"]
+    assert meta["count"] == 5
+    assert meta["min_joins"] == 3

--- a/tests/test_run_tasks.py
+++ b/tests/test_run_tasks.py
@@ -154,3 +154,28 @@ def test_single_table_multiple_pairs(tmp_path):
         {"question": "Q1", "sql": "S1"},
         {"question": "Q2", "sql": "S2"},
     ]
+
+
+def test_joins_multiple_pairs(tmp_path):
+    writer = DummyWriter()
+    job = AutonomousJob(
+        {}, writer=writer, client=DummyClient(), validator=DummyValidator(), critic=None
+    )
+
+    async def _rt(t):
+        return JobResult("", "", [
+            {"question": "JQ1", "sql": "JS1"},
+            {"question": "JQ2", "sql": "JS2"},
+        ])
+
+    job.run_task = _rt
+    t = {
+        "phase": "joins",
+        "question": "",
+        "metadata": {"dataset_output_file_dir": str(tmp_path)},
+    }
+    job.run_tasks([t])
+    assert writer.seen == [
+        {"question": "JQ1", "sql": "JS1"},
+        {"question": "JQ2", "sql": "JS2"},
+    ]


### PR DESCRIPTION
## Summary
- implement joins phase with parallel JoinPool/JoinWorker
- add join prompt template and config option `min_joins`
- support joins results when writing datasets
- tests for new loader options and dataset writing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d34962aec832aab602e05a2711a1a