### PR TITLE
Improve join generation logic

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -24,7 +24,6 @@ phases:
 
   - name: joins
     count: 25
-    examples_file: fewshot/multi_table_examples.yaml
     use_sample_rows: false
     min_joins: 2
     dataset_output_file_dir: generated_datasets/joins


### PR DESCRIPTION
## Summary
- enforce minimum joined tables in `join_worker`
- remove deprecated `examples_file` from sample config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d36a9c028832ab433ed95335d5fae