### PR TITLE
Enhance join phase with GPT selected tables

### DIFF
--- a/nl_sql_generator/prompt_template/join_set_template.txt
+++ b/nl_sql_generator/prompt_template/join_set_template.txt
@@ -1,0 +1,6 @@
+### role: system
+You are a PostgreSQL expert. Based on the provided schema, suggest {{count}} sets of tables that can be joined together. Each set must contain at least {{min_joins}} tables. Reply with one JSON object per line using the key "tables" containing the list of table names and no explanations.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}

--- a/tests/test_join_pool.py
+++ b/tests/test_join_pool.py
@@ -7,23 +7,29 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from nl_sql_generator.join_pool import JoinPool
 
+
 class DummyWriter:
     def __init__(self):
         self.queries = []
+
     def fetch(self, sql, n_rows=5):
         self.queries.append(sql)
         return [{"id": 1}]
+
 
 class DummyClient:
     async def acomplete(self, *args, **kwargs):
         return ""
 
+
 class DummyWorker:
     def __init__(self, schema, cfg, validator_cls, critic, writer, wid, client):
         self.cfg = cfg
         DummyWorker.last_cfg = cfg
+
     async def generate(self, batch_size):
         return []
+
 
 def test_join_pool_passes_sample_rows(monkeypatch):
     schema = {"a": {}, "b": {}}
@@ -31,7 +37,20 @@ def test_join_pool_passes_sample_rows(monkeypatch):
     client = DummyClient()
 
     monkeypatch.setattr("nl_sql_generator.join_pool.JoinWorker", DummyWorker)
-    pool = JoinPool(schema, {"use_sample_rows": True, "n_rows": 1, "parallelism": 1}, object, writer, None, client)
+
+    async def _chunks(self):
+        return [{"a": {}, "b": {}}]
+
+    monkeypatch.setattr("nl_sql_generator.join_pool.JoinPool._schema_chunks", _chunks)
+
+    pool = JoinPool(
+        schema,
+        {"use_sample_rows": True, "n_rows": 1, "parallelism": 1},
+        object,
+        writer,
+        None,
+        client,
+    )
     asyncio.run(pool.generate())
     # writer.fetch should be called for each table
     assert len(writer.queries) >= 2
@@ -52,6 +71,14 @@ def test_join_pool_cleans_sql(monkeypatch):
     writer = DummyWriter()
     client = DummyClient()
     monkeypatch.setattr("nl_sql_generator.join_pool.JoinWorker", Worker)
-    pool = JoinPool(schema, {"parallelism": 1, "count": 2}, object, writer, None, client)
+
+    async def _chunks(self):
+        return [schema]
+
+    monkeypatch.setattr("nl_sql_generator.join_pool.JoinPool._schema_chunks", _chunks)
+
+    pool = JoinPool(
+        schema, {"parallelism": 1, "count": 2}, object, writer, None, client
+    )
     result = asyncio.run(pool.generate())
     assert sorted(p["sql"] for p in result) == ["SELECT * FROM a", "SELECT * FROM b"]


### PR DESCRIPTION
## Summary
- introduce `join_set_template.txt` for selecting joinable table groups via GPT
- update `JoinPool` to request join table sets from GPT and pass sample rows
- improve logging across join pool and worker
- adapt tests for new async table selection logic

## Testing
- `pip install PyYAML faker SQLAlchemy openai rich numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d51b42bac832ab8537dbaa03292af