### PR TITLE
Add schema tagging in dataset output

### DIFF
--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -1,5 +1,6 @@
 defaults:
   parallelism: 10
+  tag_schema_json: true
 phases:
   - name: builtins
     count: 5
@@ -7,6 +8,7 @@ phases:
     prompt_template: builtin_sql_template.txt
     use_sample_rows: true
     dataset_output_file_dir: generated_datasets/builtins
+    tag_schema_json: true
 
   - name: schema_docs
     count: 100
@@ -14,6 +16,7 @@ phases:
     prompt_template: schema_doc_template.txt
     use_sample_rows: false
     dataset_output_file_dir: generated_datasets/schema_docs
+    tag_schema_json: true
 
 
   - name: single_table
@@ -21,23 +24,27 @@ phases:
     use_sample_rows: true
     prompt_template: single_table_sql_template.txt
     dataset_output_file_dir: generated_datasets/single_table
+    tag_schema_json: true
 
   - name: joins
     count: 2
     use_sample_rows: true
     min_joins: 2
     dataset_output_file_dir: generated_datasets/joins
+    tag_schema_json: true
 
   - name: sample_data
     n_rows: 2
     use_sample_rows: true
     dataset_output_file_dir: generated_datasets/sample_data
+    tag_schema_json: true
 
   - name: schema_relationship
     count: 100
     n_rows: 500
     prompt_template: schema_relationship_template.txt
     dataset_output_file_dir: generated_datasets/schema_relationship
+    tag_schema_json: true
 
 budget_usd: 10.0
 openai_model: gpt-4.1


### PR DESCRIPTION
## Summary
- add `tag_schema_json` setting for all phases
- include schema details when writing dataset entries
- test schema tagging behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d62660d70832aaac235442e5958d3