### PR TITLE
Fix JSON serialization for UUID

### DIFF
--- a/nl_sql_generator/schema_relationship.py
+++ b/nl_sql_generator/schema_relationship.py
@@ -252,7 +252,7 @@ async def _gpt_relationship_sqls(
         },
         {
             "role": "user",
-            "content": f"SCHEMA_JSON:\n{json.dumps(schema_json, indent=2)}\n\nSAMPLE_ROWS:\n{json.dumps(rows, indent=2)}",
+            "content": f"SCHEMA_JSON:\n{json.dumps(schema_json, indent=2, default=str)}\n\nSAMPLE_ROWS:\n{json.dumps(rows, indent=2, default=str)}",
         },
     ]
 


### PR DESCRIPTION
## Summary
- fix JSON dumps when rows contain UUID objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d771f2d94832aa813c504585c63c5