### PR TITLE
Fix budget inheritance in OpenAI helper

### DIFF
--- a/nl_sql_generator/schema_relationship.py
+++ b/nl_sql_generator/schema_relationship.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - optional dependency
     openai = None
 
 from .schema_loader import TableInfo, SchemaLoader
-from .openai_responses import acomplete
+from .openai_responses import acomplete, _load_budget
 
 __all__ = ["discover_relationships"]
 
@@ -186,7 +186,7 @@ async def _gpt_second_opinion(
 ) -> str:
     """Ask GPT to confirm a relationship and return its verdict."""
 
-    budget = float(os.getenv("OPENAI_BUDGET_USD", "0"))
+    budget = _load_budget()
     if openai is None or os.getenv("OPENAI_API_KEY") is None or budget <= 0:
         return "yes"
 


### PR DESCRIPTION
## Summary
- load OpenAI budget from config.yaml when env var missing
- ensure relationship discovery phase inherits config budget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7e8626d8832a8ebf17cfe68255d0