### PR TITLE
Add complex_sqls data generation phase

### DIFF
--- a/nl_sql_generator/complex_sql_pool.py
+++ b/nl_sql_generator/complex_sql_pool.py
@@ -1,0 +1,188 @@
+"""Orchestrate JoinWorker agents for complex multi-table queries."""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+import logging
+from typing import Any, Dict, List
+
+from .prompt_builder import load_template_messages
+from .join_worker import JoinWorker
+from .openai_responses import ResponsesClient
+from .autonomous_job import _clean_sql
+
+
+class ComplexSqlPool:
+    """Generate join-based NL/SQL pairs using richer table selection."""
+
+    def __init__(
+        self,
+        schema: Dict[str, Any],
+        phase_cfg: Dict[str, Any],
+        validator_cls,
+        writer,
+        critic,
+        client: ResponsesClient,
+    ) -> None:
+        self.schema = schema
+        self.cfg = phase_cfg
+        self.validator_cls = validator_cls
+        self.writer = writer
+        self.critic = critic
+        self.client = client
+        self.seen: set[tuple[str, str]] = set()
+        self.lock = asyncio.Lock()
+        self.log = logging.getLogger(__name__)
+
+    async def _schema_chunks(self) -> List[Dict[str, Any]]:
+        """Return table subsets for each worker using GPT suggestions."""
+
+        n = int(self.cfg.get("parallelism", 1))
+        min_joins = int(self.cfg.get("min_joins", 3))
+        extra: Dict[str, Any] = {"count": n, "min_joins": min_joins}
+
+        if self.cfg.get("use_sample_rows"):
+            n_rows = int(self.cfg.get("n_rows", 20))
+            sample_rows: Dict[str, List[Dict[str, Any]]] = {}
+            for t in self.schema:
+                try:
+                    sample_rows[t] = self.writer.fetch(
+                        f"SELECT * FROM {t} LIMIT {n_rows}", n_rows
+                    )
+                except Exception as err:  # pragma: no cover - depends on DB
+                    self.log.warning("Failed fetching rows for %s: %s", t, err)
+            if sample_rows:
+                extra["sample_rows"] = sample_rows
+                self.log.info("Loaded sample rows for %s", list(sample_rows))
+
+        self.log.info("Requesting %d complex join table sets", n)
+        try:
+            messages = load_template_messages(
+                "complex_set_template.txt", self.schema, "", extra
+            )
+            text = await self.client.acomplete(messages)
+        except Exception as err:  # pragma: no cover - network failures
+            self.log.warning("Failed requesting table sets: %s", err)
+            text = ""
+
+        sets: List[List[str]] = []
+        for line in text.splitlines():
+            line = line.strip().lstrip("-*0123456789. ").strip("`")
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                tbls = obj.get("tables")
+            else:
+                tbls = obj
+            if not isinstance(tbls, list):
+                continue
+            tbls = [t for t in tbls if t in self.schema]
+            if len(tbls) >= min_joins:
+                sets.append(tbls)
+
+        if not sets:
+            sets = [list(self.schema.keys())]
+
+        chunks = [{t: self.schema[t] for t in tbls} for tbls in sets[:n]]
+        self.log.info("GPT suggested table sets: %s", sets[:n])
+        return chunks
+
+    async def _run_worker(
+        self, batch_size: int, worker_id: int, schema_subset: Dict[str, Any]
+    ) -> int:
+        cfg = dict(self.cfg)
+        cfg.setdefault("min_joins", 3)
+        if cfg.get("use_sample_rows"):
+            n_rows = int(cfg.get("n_rows", 20))
+            sample_rows: Dict[str, List[Dict[str, Any]]] = {}
+            for t in schema_subset:
+                try:
+                    sample_rows[t] = self.writer.fetch(
+                        f"SELECT * FROM {t} LIMIT {n_rows}", n_rows
+                    )
+                except Exception as err:
+                    self.log.warning(
+                        "Worker %d failed fetching rows for %s: %s",
+                        worker_id,
+                        t,
+                        err,
+                    )
+            if sample_rows:
+                cfg["sample_rows"] = sample_rows
+                self.log.info(
+                    "Worker %d loaded sample rows for %s",
+                    worker_id,
+                    list(sample_rows),
+                )
+        self.log.info(
+            "Worker %d starting batch size %d with tables %s",
+            worker_id,
+            batch_size,
+            list(schema_subset),
+        )
+        agent = JoinWorker(
+            schema_subset,
+            cfg,
+            self.validator_cls,
+            self.critic,
+            self.writer,
+            worker_id,
+            self.client,
+        )
+        pairs = await agent.generate(batch_size)
+        async with self.lock:
+            before = len(self.seen)
+            for p in pairs:
+                self.seen.add((p["question"], p["sql"]))
+            delta = len(self.seen) - before
+        self.log.info("Worker %d produced %d new pairs", worker_id, delta)
+        return delta
+
+    async def generate(self) -> List[Dict[str, str]]:
+        per_worker = int(self.cfg.get("count", 1))
+        schema_chunks = await self._schema_chunks()
+        n_workers = len(schema_chunks)
+        self.log.info("Spawning %d workers", n_workers)
+        attempts = 0
+        produced = [0] * n_workers
+        self.log.info(
+            "Starting complex join generation: per_worker=%d parallelism=%d",
+            per_worker,
+            n_workers,
+        )
+
+        while (
+            any(p < per_worker for p in produced)
+            and attempts < self.cfg.get("max_attempts", 6)
+        ):
+            jobs = []
+            for i in range(n_workers):
+                remaining = per_worker - produced[i]
+                if remaining > 0:
+                    jobs.append(self._run_worker(remaining, i, schema_chunks[i]))
+                else:
+                    jobs.append(asyncio.sleep(0, result=0))
+
+            deltas = await asyncio.gather(*jobs)
+            for i, d in enumerate(deltas):
+                produced[i] += d
+
+            attempts += 1
+            self.log.info(
+                "Attempt %d complete, per-worker totals=%s", attempts, produced
+            )
+
+        total_goal = per_worker * n_workers
+        self.log.info(
+            "Complex join generation finished with %d pairs", len(self.seen)
+        )
+        return [
+            {"question": q, "sql": _clean_sql(s)}
+            for q, s in itertools.islice(self.seen, total_goal)
+        ]

--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -33,6 +33,13 @@ phases:
     dataset_output_file_dir: generated_datasets/joins
     tag_schema_json: true
 
+  - name: complex_sqls
+    count: 2
+    use_sample_rows: true
+    min_joins: 3
+    dataset_output_file_dir: generated_datasets/complex_sqls
+    tag_schema_json: true
+
   - name: sample_data
     n_rows: 2
     use_sample_rows: true

--- a/nl_sql_generator/input_loader.py
+++ b/nl_sql_generator/input_loader.py
@@ -153,6 +153,18 @@ def load_tasks(
             meta_with_count = {**meta, "count": count, "min_joins": min_joins}
             tasks.append({"phase": name, "question": q, "metadata": meta_with_count})
             continue
+        if name.lower() == "complex_sqls":
+            count = int(phase_def.get("count", 1))
+            min_joins = int(phase_def.get("min_joins", 3))
+            q = str(
+                phase_def.get(
+                    "question",
+                    f"Generate {count} complex question/SQL pairs requiring joins.",
+                )
+            )
+            meta_with_count = {**meta, "count": count, "min_joins": min_joins}
+            tasks.append({"phase": name, "question": q, "metadata": meta_with_count})
+            continue
         questions = phase_def.get("questions")
         if questions:
             for q in questions:

--- a/nl_sql_generator/prompt_template/complex_set_template.txt
+++ b/nl_sql_generator/prompt_template/complex_set_template.txt
@@ -1,0 +1,9 @@
+### role: system
+You are a PostgreSQL expert. Using the schema and sample rows, suggest {{count}} sets of tables that can be joined together. Each set must contain at least {{min_joins}} tables. Reply with one JSON object per line using the key "tables" containing only the table names and no explanations.
+
+### role: user
+SCHEMA_JSON:
+{{schema_json}}
+
+SAMPLE_ROWS:
+{{sample_rows}}

--- a/tests/test_complex_sql_pool.py
+++ b/tests/test_complex_sql_pool.py
@@ -1,0 +1,77 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nl_sql_generator.complex_sql_pool import ComplexSqlPool
+
+
+class DummyWriter:
+    def __init__(self):
+        self.queries = []
+
+    def fetch(self, sql, n_rows=5):
+        self.queries.append(sql)
+        return [{"id": 1}]
+
+
+class DummyClient:
+    async def acomplete(self, *args, **kwargs):
+        # single set with two tables
+        return '{"tables": ["a", "b"]}'
+
+
+class DummyWorker:
+    def __init__(self, schema, cfg, validator_cls, critic, writer, wid, client):
+        self.cfg = cfg
+        DummyWorker.last_cfg = cfg
+
+    async def generate(self, batch_size):
+        return []
+
+
+def test_complex_pool_fetches_rows_for_chunks(monkeypatch):
+    schema = {"a": {}, "b": {}}
+    writer = DummyWriter()
+    client = DummyClient()
+
+    pool = ComplexSqlPool(
+        schema,
+        {"use_sample_rows": True, "n_rows": 1, "parallelism": 1},
+        object,
+        writer,
+        None,
+        client,
+    )
+    chunks = asyncio.run(pool._schema_chunks())
+    assert len(writer.queries) == 2
+    assert chunks and list(chunks[0].keys()) == ["a", "b"]
+
+
+def test_complex_pool_default_min_joins(monkeypatch):
+    schema = {"a": {}, "b": {}, "c": {}}
+    writer = DummyWriter()
+    client = DummyClient()
+
+    monkeypatch.setattr(
+        "nl_sql_generator.complex_sql_pool.JoinWorker", DummyWorker
+    )
+
+    async def _chunks(self):
+        return [{"a": {}, "b": {}, "c": {}}]
+
+    monkeypatch.setattr(
+        "nl_sql_generator.complex_sql_pool.ComplexSqlPool._schema_chunks", _chunks
+    )
+
+    pool = ComplexSqlPool(
+        schema,
+        {"parallelism": 1, "count": 1},
+        object,
+        writer,
+        None,
+        client,
+    )
+    asyncio.run(pool.generate())
+    assert DummyWorker.last_cfg["min_joins"] == 3

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -192,3 +192,19 @@ phases:
     meta = tasks[0]["metadata"]
     assert meta["count"] == 5
     assert meta["min_joins"] == 3
+
+def test_complex_sqls_phase(tmp_path):
+    cfg = """
+phases:
+  - name: complex_sqls
+    count: 4
+    min_joins: 5
+"""
+    path = tmp_path / "cfg.yaml"
+    path.write_text(cfg)
+
+    tasks = load_tasks(str(path), {"t1": object(), "t2": object()})
+    assert len(tasks) == 1
+    meta = tasks[0]["metadata"]
+    assert meta["count"] == 4
+    assert meta["min_joins"] == 5


### PR DESCRIPTION
## Summary
- implement `ComplexSqlPool` for GPT-driven table selection using sample rows
- update `input_loader` and `autonomous_job` to support new `complex_sqls` phase
- add prompt template for complex join table sets
- document phase in `config.yaml`
- test new pool and loader behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729f96cd14832aa7fbf5f93ec3126f