### PR TITLE
Fix complex sql parallelism

### DIFF
--- a/nl_sql_generator/complex_sql_pool.py
+++ b/nl_sql_generator/complex_sql_pool.py
@@ -8,6 +8,10 @@ import json
 import logging
 from typing import Any, Dict, List
 
+# Default concurrency used when ``parallelism`` is not provided via
+# phase configuration.
+DEFAULT_PARALLELISM = 10
+
 from .prompt_builder import load_template_messages
 from .join_worker import JoinWorker
 from .openai_responses import ResponsesClient
@@ -39,7 +43,7 @@ class ComplexSqlPool:
     async def _schema_chunks(self) -> List[Dict[str, Any]]:
         """Return table subsets for each worker using GPT suggestions."""
 
-        n = int(self.cfg.get("parallelism", 1))
+        n = int(self.cfg.get("parallelism", DEFAULT_PARALLELISM))
         min_joins = int(self.cfg.get("min_joins", 3))
         extra: Dict[str, Any] = {"count": n, "min_joins": min_joins}
 

--- a/nl_sql_generator/config.yaml
+++ b/nl_sql_generator/config.yaml
@@ -36,7 +36,7 @@ phases:
   - name: complex_sqls
     count: 10
     use_sample_rows: true
-    parallelism=50
+    parallelism: 50
     min_joins: 3
     dataset_output_file_dir: generated_datasets/complex_sqls
     tag_schema_json: false

--- a/tests/test_complex_sql_pool.py
+++ b/tests/test_complex_sql_pool.py
@@ -75,3 +75,27 @@ def test_complex_pool_default_min_joins(monkeypatch):
     )
     asyncio.run(pool.generate())
     assert DummyWorker.last_cfg["min_joins"] == 3
+
+
+def test_complex_pool_uses_default_parallelism(monkeypatch):
+    captured = {}
+
+    def _load_template(_, __, ___, extra):
+        captured["count"] = extra.get("count")
+        return []
+
+    class _Client(DummyClient):
+        async def acomplete(self, *args, **kwargs):
+            return ""
+
+    monkeypatch.setattr(
+        "nl_sql_generator.complex_sql_pool.load_template_messages",
+        _load_template,
+    )
+    schema = {"a": {}, "b": {}}
+    writer = DummyWriter()
+    client = _Client()
+
+    pool = ComplexSqlPool(schema, {}, object, writer, None, client)
+    asyncio.run(pool._schema_chunks())
+    assert captured["count"] == 10


### PR DESCRIPTION
## Summary
- configure default parallelism for complex SQL workers
- fix YAML syntax for complex_sqls phase
- test default parallelism fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b5236348832a8b04a2d1bd5cdde2