### PR TITLE
Fix schema loader to print schema JSON

### DIFF
--- a/nl_sql_generator/schema_loader.py
+++ b/nl_sql_generator/schema_loader.py
@@ -128,6 +128,6 @@ class SchemaLoader:
 
 if __name__ == "__main__":
     # quick manual test
+    logging.basicConfig(level=logging.INFO)
     schema = SchemaLoader.load_schema()
-    log = logging.getLogger(__name__)
-    log.info(json.dumps(SchemaLoader.to_json(schema), indent=2))
+    print(json.dumps(SchemaLoader.to_json(schema), indent=2))


### PR DESCRIPTION
## Summary
- ensure `python -m nl_sql_generator.schema_loader` prints to stdout

## Testing
- `pip install PyYAML Faker SQLAlchemy openai rich Jinja2 requests typer numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872c6a9039c832aab6b0f51e5746e94