### PR TITLE
Add foreign key info to SchemaLoader

### DIFF
--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -22,6 +22,15 @@ class DummyInspector:
     def get_table_comment(self, table):
         return {"text": "tbl comment"}
 
+    def get_foreign_keys(self, table):
+        return [
+            {
+                "referred_table": "parent",
+                "constrained_columns": ["parent_id"],
+                "referred_columns": ["id"],
+            }
+        ]
+
 
 class DummyEngine:
     pass
@@ -39,3 +48,4 @@ def test_load_schema_with_comments(monkeypatch):
     info = schema["tbl"]
     assert info.comment == "tbl comment"
     assert info.columns[0].comment == "pk"
+    assert info.foreign_keys[0]["referred_table"] == "parent"


### PR DESCRIPTION
## Summary
- capture foreign key constraints when loading schema
- expose the foreign keys via TableInfo dataclass
- include foreign key info in JSON output
- test SchemaLoader foreign key handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872cad2770c832abadd9bd718eafd2e