### PR TITLE
Add worker logging for schema_docs follow-up requests

### DIFF
--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -109,6 +109,14 @@ class WorkerAgent:
                 break
             if attempts < max_attempts:
                 remaining = min(api_count, k - len(total))
+                log.info(
+                    "Worker %d received %d pairs, requesting %d more (%d/%d remaining)",
+                    self.wid,
+                    len(pairs),
+                    remaining,
+                    k - len(total),
+                    k,
+                )
                 messages.append(
                     {
                         "role": "user",


### PR DESCRIPTION
## Summary
- log when schema_docs workers ask the API for more pairs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e5901a90832a91648b118e7de44f