### PR TITLE
Fix schema_doc pair counting

### DIFF
--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -11,7 +11,10 @@ class DummyClient:
     async def acomplete(self, messages, return_message=False, model=None):
         self.calls.append(messages)
         text = "\n".join(
-            [f'{{"question": "Q{len(self.calls)}-{i}", "answer": "A{i}"}}' for i in range(2)]
+            [
+                f'{{"question": "Q{len(self.calls)}-{i}", "answer": "A{i}"}}'
+                for i in range(2)
+            ]
         )
         if return_message:
             return {"role": "assistant", "content": text}
@@ -22,7 +25,10 @@ class SinglePairClient(DummyClient):
     async def acomplete(self, messages, return_message=False, model=None):
         self.calls.append(messages)
         text = "\n".join(
-            [f'{{"question": "Q{len(self.calls)}-{i}", "answer": "A{i}"}}' for i in range(1)]
+            [
+                f'{{"question": "Q{len(self.calls)}-{i}", "answer": "A{i}"}}'
+                for i in range(1)
+            ]
         )
         if return_message:
             return {"role": "assistant", "content": text}
@@ -76,11 +82,21 @@ def test_parse_pairs_with_noise():
     ]
 
 
+def test_parse_pairs_json_array():
+    text = """[
+        {"question": "Q1", "answer": "A1"},
+        {"question": "Q2", "answer": "A2"}
+    ]"""
+    pairs = _parse_pairs(text)
+    assert pairs == [
+        {"question": "Q1", "answer": "A1"},
+        {"question": "Q2", "answer": "A2"},
+    ]
+
+
 def test_generate_multiple_requests():
     client = DummyClient()
-    schema = {
-        "t": TableInfo("t", [ColumnInfo("id", "int")])
-    }
+    schema = {"t": TableInfo("t", [ColumnInfo("id", "int")])}
     agent = WorkerAgent(schema, {"api_answer_count": 2}, lambda: None, 1, client)
     pairs = asyncio.run(agent.generate(3))
 
@@ -89,34 +105,26 @@ def test_generate_multiple_requests():
     assert len(client.calls) == 2
     # Schema JSON should only appear once across the chat history
     call2 = client.calls[1]
-    schema_mentions = sum(
-        "SCHEMA_JSON" in m.get("content", "") for m in call2
-    )
+    schema_mentions = sum("SCHEMA_JSON" in m.get("content", "") for m in call2)
     assert schema_mentions == 1
 
 
 def test_schema_included_once_per_call():
     client = SinglePairClient()
-    schema = {
-        "t": TableInfo("t", [ColumnInfo("id", "int")])
-    }
+    schema = {"t": TableInfo("t", [ColumnInfo("id", "int")])}
     agent = WorkerAgent(schema, {"api_answer_count": 1}, lambda: None, 1, client)
     pairs = asyncio.run(agent.generate(3))
 
     assert len(pairs) == 3
     assert len(client.calls) == 3
     for call in client.calls:
-        schema_mentions = sum(
-            "SCHEMA_JSON" in m.get("content", "") for m in call
-        )
+        schema_mentions = sum("SCHEMA_JSON" in m.get("content", "") for m in call)
         assert schema_mentions == 1
 
 
 def test_generate_respects_max_attempts():
     client = EmptyClient()
-    schema = {
-        "t": TableInfo("t", [ColumnInfo("id", "int")])
-    }
+    schema = {"t": TableInfo("t", [ColumnInfo("id", "int")])}
     agent = WorkerAgent(
         schema,
         {"api_answer_count": 2, "max_attempts": 2},
@@ -133,9 +141,7 @@ def test_generate_respects_max_attempts():
 def test_stop_when_batch_met():
     k = 2
     client = FullBatchClient(k)
-    schema = {
-        "t": TableInfo("t", [ColumnInfo("id", "int")])
-    }
+    schema = {"t": TableInfo("t", [ColumnInfo("id", "int")])}
     agent = WorkerAgent(schema, {"api_answer_count": k}, lambda: None, 1, client)
     pairs = asyncio.run(agent.generate(k))
 


### PR DESCRIPTION
## Summary
- handle JSON arrays in worker_agent.parse_pairs
- test parsing of arrays in worker_agent

## Testing
- `ruff check nl_sql_generator/worker_agent.py tests/test_worker_agent.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e8990950832ab20774e34a74a40d