### PR TITLE
Fix schema_docs worker pair counting

### DIFF
--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -23,8 +23,10 @@ def _parse_pairs(text: str) -> List[Dict[str, str]]:
             continue
         # Drop common list prefixes like "-" or "1." and code fence ticks
         line = line.lstrip("-*0123456789. ").strip("`")
-        if line:
-            lines.append(line)
+        # Skip chatter like "Here are the pairs:" which breaks JSON parsing
+        if not line or line[0] not in "[{]}":
+            continue
+        lines.append(line)
 
     cleaned = "\n".join(lines)
     pairs: List[Dict[str, str]] = []

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -94,6 +94,21 @@ def test_parse_pairs_json_array():
     ]
 
 
+def test_parse_pairs_with_preamble():
+    text = """Sure, here are some pairs:
+```json
+[
+  {"question": "Q1", "answer": "A1"},
+  {"question": "Q2", "answer": "A2"}
+]
+```"""
+    pairs = _parse_pairs(text)
+    assert pairs == [
+        {"question": "Q1", "answer": "A1"},
+        {"question": "Q2", "answer": "A2"},
+    ]
+
+
 def test_generate_multiple_requests():
     client = DummyClient()
     schema = {"t": TableInfo("t", [ColumnInfo("id", "int")])}


### PR DESCRIPTION
## Summary
- filter non-JSON chatter when parsing schema docs responses
- add regression test for parsing JSON with a preamble

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874edee0194832aa921e736418d1639