### PR TITLE
Fix remaining pair count in worker_agent

### DIFF
--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -129,7 +129,7 @@ class WorkerAgent:
             if len(total) >= k:
                 break
             if attempts < max_attempts:
-                remaining = min(api_count, k - len(total))
+                remaining = max(0, min(api_count - len(pairs), k - len(total)))
                 log.info(
                     "Worker %d received %d pairs, requesting %d more (%d/%d remaining)",
                     self.wid,

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -162,3 +162,15 @@ def test_stop_when_batch_met():
 
     assert len(pairs) == k
     assert len(client.calls) == 1
+
+
+def test_remaining_uses_pairs_received():
+    client = SinglePairClient()
+    schema = {"t": TableInfo("t", [ColumnInfo("id", "int")])}
+    agent = WorkerAgent(schema, {"api_answer_count": 2}, lambda: None, 1, client)
+    pairs = asyncio.run(agent.generate(3))
+
+    assert len(pairs) == 3
+    assert len(client.calls) >= 2
+    # Second request should ask for only one additional pair
+    assert "Generate 1 more" in client.calls[1][-2]["content"]


### PR DESCRIPTION
## Summary
- correct remaining pair calculation in `WorkerAgent.generate`
- test requesting fewer pairs after partial batch

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f2e8f2a0832a8fbaa53fcb823d74