### PR TITLE
Add per-worker chat history logging

### DIFF
--- a/nl_sql_generator/join_worker.py
+++ b/nl_sql_generator/join_worker.py
@@ -1,5 +1,7 @@
 import logging
 import json
+import os
+from datetime import datetime
 import re
 from typing import Any, Dict, List
 from .openai_responses import ResponsesClient
@@ -43,6 +45,30 @@ class JoinWorker:
         self.wid = wid
         self.client = client
 
+        self.chat_history: List[Dict[str, str]] = []
+        self.chat_log_path: str | None = None
+        if self.cfg.get("enable_worker_chat_log"):
+            os.makedirs("logs", exist_ok=True)
+            ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+            self.chat_log_path = os.path.join(
+                "logs", f"join-worker-{self.wid}-{ts}.jsonl"
+            )
+            log.info(
+                "Join worker %d chat log enabled at %s", self.wid, self.chat_log_path
+            )
+
+    def _log_message(self, msg: Dict[str, str]) -> None:
+        """Append ``msg`` to the chat history log if enabled."""
+        if not self.chat_log_path:
+            return
+        self.chat_history.append(msg)
+        try:
+            with open(self.chat_log_path, "a", encoding="utf-8") as fh:
+                json.dump(msg, fh)
+                fh.write("\n")
+        except Exception as err:  # pragma: no cover - logging only
+            log.warning("Join worker %d failed to write chat log: %s", self.wid, err)
+
     def _join_table_count(self, sql: str) -> int:
         """Return number of tables referenced via FROM/JOIN clauses."""
         pattern = re.compile(r"\b(?:FROM|JOIN)\s+([\w\.\"`]+)", re.IGNORECASE)
@@ -69,13 +95,16 @@ class JoinWorker:
         messages = load_template_messages(
             "join_sql_template.txt", self.schema, "", extra
         )
+        for m in messages:
+            self._log_message(m)
         log.info(
             "Worker %d sending prompt with tables %s",
             self.wid,
             list(self.schema),
         )
-        completion = await self.client.acomplete(messages)
-        pairs = _parse_pairs(completion)
+        message = await self.client.acomplete(messages, return_message=True)
+        self._log_message(message)
+        pairs = _parse_pairs(message.get("content", ""))
         results: List[Dict[str, str]] = []
         min_joins = int(self.cfg.get("min_joins", 2))
         for p in pairs:
@@ -102,4 +131,10 @@ class JoinWorker:
                 except Exception as err:
                     log.warning("Worker %d execution failed: %s", self.wid, err)
         log.info("Worker %d produced %d valid pairs", self.wid, len(results))
+        if self.chat_log_path:
+            log.info(
+                "Join worker %d chat history saved to %s",
+                self.wid,
+                self.chat_log_path,
+            )
         return results

--- a/nl_sql_generator/worker_agent.py
+++ b/nl_sql_generator/worker_agent.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import os
+from datetime import datetime
 from typing import Any, Dict, List
 
 log = logging.getLogger(__name__)
@@ -87,6 +89,30 @@ class WorkerAgent:
         self.wid = wid
         self.client = client
 
+        self.chat_history: List[Dict[str, str]] = []
+        self.chat_log_path: str | None = None
+        if self.cfg.get("enable_worker_chat_log"):
+            os.makedirs("logs", exist_ok=True)
+            ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+            self.chat_log_path = os.path.join(
+                "logs", f"worker-{self.wid}-{ts}.jsonl"
+            )
+            log.info(
+                "Worker %d chat log enabled at %s", self.wid, self.chat_log_path
+            )
+
+    def _log_message(self, msg: Dict[str, str]) -> None:
+        """Append ``msg`` to the chat history log if enabled."""
+        if not self.chat_log_path:
+            return
+        self.chat_history.append(msg)
+        try:
+            with open(self.chat_log_path, "a", encoding="utf-8") as fh:
+                json.dump(msg, fh)
+                fh.write("\n")
+        except Exception as err:  # pragma: no cover - logging only
+            log.warning("Worker %d failed to write chat log: %s", self.wid, err)
+
     async def generate(self, k: int) -> List[Dict[str, str]]:
         """Return ``k`` Q&A pairs generated from this worker's schema slice.
 
@@ -111,6 +137,8 @@ class WorkerAgent:
         messages: List[Dict[str, str]] = build_schema_doc_prompt(
             self.schema, k=first_request
         )
+        for m in messages:
+            self._log_message(m)
         total: List[Dict[str, str]] = []
 
         attempts = 0
@@ -125,6 +153,7 @@ class WorkerAgent:
                 if len(total) >= k:
                     break
             messages.append(msg)
+            self._log_message(msg)
             attempts += 1
             if len(total) >= k:
                 break
@@ -138,12 +167,12 @@ class WorkerAgent:
                     k - len(total),
                     k,
                 )
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": f"Generate {remaining} more question-answer pairs about the schema.",
-                    }
-                )
+                follow = {
+                    "role": "user",
+                    "content": f"Generate {remaining} more question-answer pairs about the schema.",
+                }
+                messages.append(follow)
+                self._log_message(follow)
 
         if len(total) < k:
             log.warning(
@@ -155,4 +184,8 @@ class WorkerAgent:
             )
         else:
             log.info("Worker %d produced %d pairs", self.wid, len(total))
+        if self.chat_log_path:
+            log.info(
+                "Worker %d chat history saved to %s", self.wid, self.chat_log_path
+            )
         return total[:k]

--- a/tests/test_join_worker.py
+++ b/tests/test_join_worker.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nl_sql_generator.join_worker import JoinWorker
+from nl_sql_generator.schema_loader import TableInfo, ColumnInfo
+
+
+class DummyValidator:
+    def check(self, sql):
+        return True, ""
+
+
+class DummyCritic:
+    async def areview(self, q, sql, schema_md):
+        return {}
+
+
+class DummyWriter:
+    def fetch(self, sql, n_rows=5):
+        return []
+
+
+class DummyClient:
+    async def acomplete(self, messages, return_message=False, model=None):
+        text = '{"question": "Q1", "sql": "SELECT * FROM a JOIN b"}'
+        if return_message:
+            return {"role": "assistant", "content": text}
+        return text
+
+
+def test_chat_log_created(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    schema = {
+        "a": TableInfo("a", [ColumnInfo("id", "int")]),
+        "b": TableInfo("b", [ColumnInfo("id", "int")]),
+    }
+    worker = JoinWorker(
+        schema,
+        {"enable_worker_chat_log": True},
+        DummyValidator,
+        DummyCritic(),
+        DummyWriter(),
+        1,
+        DummyClient(),
+    )
+    asyncio.run(worker.generate(1))
+    log_files = list((tmp_path / "logs").glob("join-worker-1-*.jsonl"))
+    assert len(log_files) == 1
+    data = [json.loads(l) for l in log_files[0].read_text().splitlines()]
+    assert any(m["role"] == "assistant" for m in data)


### PR DESCRIPTION
## Summary
- log chat history for WorkerAgent and JoinWorker when `enable_worker_chat_log` is set
- save history to `logs/worker-<id>-*.jsonl` or `logs/join-worker-<id>-*.jsonl`
- test that chat history logs are created
- write chat logs incrementally instead of waiting for process end

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874fb86e6b0832a883901eb51744978